### PR TITLE
Added size element int JSON group declaration.

### DIFF
--- a/public/kibi_timeline_vis_controller.js
+++ b/public/kibi_timeline_vis_controller.js
@@ -75,7 +75,8 @@ define(function (require) {
               params: {
                 labelField: group.labelField,
                 startField: group.startField,
-                endField: group.endField
+                endField: group.endField,
+                size: group.size
               }
             });
           });


### PR DESCRIPTION
I added a size element in the declaration of the group(s) elements. As it was, the size field from the Options panel was being ignored on Redraw, and only considered after full refresh.