### PR TITLE
sync application time to timeline

### DIFF
--- a/public/__tests__/kibi_timeline_vis_controller.js
+++ b/public/__tests__/kibi_timeline_vis_controller.js
@@ -359,6 +359,7 @@ describe('Kibi Timeline', function () {
       const savedVis = {
         vis: {
           params: {
+            syncTime: 'sync',
             groupsOnSeparateLevels: 'sep',
             notifyDataErrors: 'notify',
             selectValue: 'date',
@@ -376,6 +377,7 @@ describe('Kibi Timeline', function () {
 
       $scope.initSearchSources(savedVis)
       .then(() => {
+        expect($scope.savedObj.syncTime).to.be('sync');
         expect($scope.savedObj.groupsOnSeparateLevels).to.be('sep');
         expect($scope.savedObj.notifyDataErrors).to.be('notify');
         expect($scope.savedObj.selectValue).to.be('date');

--- a/public/kibi_timeline.js
+++ b/public/kibi_timeline.js
@@ -5,7 +5,7 @@ define(function (require) {
   let buildRangeFilter = require('ui/filter_manager/lib/range');
 
   require('ui/modules').get('kibana').directive('kibiTimeline',
-  function (Private, createNotifier, courier, indexPatterns, config, highlightTags) {
+  function (Private, createNotifier, courier, indexPatterns, config, highlightTags, $rootScope) {
     const kibiUtils = require('kibiutils');
     const NUM_FRAGS_CONFIG = 'kibi:timeline:highlight:number_of_fragments';
     const DEFAULT_NUM_FRAGS = 25;
@@ -24,7 +24,8 @@ define(function (require) {
         groupsOnSeparateLevels: '=',
         options: '=',
         selectValue: '=',
-        notifyDataErrors: '='
+        notifyDataErrors: '=',
+        syncTime: '='
       },
       restrict: 'E',
       replace: true,
@@ -118,6 +119,13 @@ define(function (require) {
             timeline.setOptions($scope.options);
           }
           timeline.on('select', onSelect);
+          timeline.on('rangechanged', function (props) {
+            if ($scope.syncTime && props.byUser) {
+              $rootScope.$$timefilter.time.mode = 'absolute';
+              $rootScope.$$timefilter.time.from = props.start.toISOString();
+              $rootScope.$$timefilter.time.to = props.end.toISOString();
+            }
+          });
         }
       };
 

--- a/public/kibi_timeline.js
+++ b/public/kibi_timeline.js
@@ -5,7 +5,7 @@ define(function (require) {
   let buildRangeFilter = require('ui/filter_manager/lib/range');
 
   require('ui/modules').get('kibana').directive('kibiTimeline',
-  function (Private, createNotifier, courier, indexPatterns, config, highlightTags, $rootScope) {
+  function (Private, createNotifier, courier, indexPatterns, config, highlightTags, timefilter) {
     const kibiUtils = require('kibiutils');
     const NUM_FRAGS_CONFIG = 'kibi:timeline:highlight:number_of_fragments';
     const DEFAULT_NUM_FRAGS = 25;
@@ -121,9 +121,9 @@ define(function (require) {
           timeline.on('select', onSelect);
           timeline.on('rangechanged', function (props) {
             if ($scope.syncTime && props.byUser) {
-              $rootScope.$$timefilter.time.mode = 'absolute';
-              $rootScope.$$timefilter.time.from = props.start.toISOString();
-              $rootScope.$$timefilter.time.to = props.end.toISOString();
+              timefilter.time.mode = 'absolute';
+              timefilter.time.from = props.start.toISOString();
+              timefilter.time.to = props.end.toISOString();
             }
           });
         }

--- a/public/kibi_timeline_vis.html
+++ b/public/kibi_timeline_vis.html
@@ -5,7 +5,8 @@
     groups-on-separate-levels="savedObj.groupsOnSeparateLevels"
     select-value="savedObj.selectValue"
     notify-data-errors="savedObj.notifyDataErrors"
-    options="options">
+    options="options"
+    sync-time="savedObj.syncTime">
   </kibi-timeline>
 
 </div>

--- a/public/kibi_timeline_vis.js
+++ b/public/kibi_timeline_vis.js
@@ -23,7 +23,8 @@ define(function (require) {
           groups: [],
           groupsOnSeparateLevels: false,
           selectValue: 'id',
-          notifyDataErrors: false
+          notifyDataErrors: false,
+          syncTime: false
         },
         editor: '<kibi-timeline-vis-params></kibi-timeline-vis-params>'
       },

--- a/public/kibi_timeline_vis_controller.js
+++ b/public/kibi_timeline_vis_controller.js
@@ -98,6 +98,7 @@ define(function (require) {
           $scope.savedObj.groupsOnSeparateLevels = savedVis.vis.params.groupsOnSeparateLevels;
           $scope.savedObj.selectValue = savedVis.vis.params.selectValue;
           $scope.savedObj.notifyDataErrors = savedVis.vis.params.notifyDataErrors;
+          $scope.savedObj.syncTime = savedVis.vis.params.syncTime;
         })
         .catch(notify.error);
       };

--- a/public/kibi_timeline_vis_params.html
+++ b/public/kibi_timeline_vis_params.html
@@ -85,6 +85,11 @@
         <label>
           <input type="checkbox" ng-model="vis.params.notifyDataErrors"/> Notify about errors in the data
         </label>
+        <label>
+          <input type="checkbox" ng-model="vis.params.syncTime"/> 
+          Sync application time to timeline
+          <kbn-info info="Turn this timeline into a control. Moving and zooming the timeline will set applcation time to timeline boundaries."></kbn-info>
+        </label>
       </div>
       <div class="form-group">
         <label>On select:</label>

--- a/public/kibi_timeline_vis_params.html
+++ b/public/kibi_timeline_vis_params.html
@@ -87,7 +87,7 @@
         </label>
         <label>
           <input type="checkbox" ng-model="vis.params.syncTime"/> 
-          Sync application time to timeline
+          Sync application time with the timeline
           <kbn-info info="Turn this timeline into a control. Moving and zooming the timeline will set applcation time to timeline boundaries."></kbn-info>
         </label>
       </div>


### PR DESCRIPTION
This pull requests adds a new advanced configuration option. When set to true, moving or zooming the timeline will update the parent application timefilter. This provides a great control for dashboards where users can zip around in the timeline and see all the other visualizations reflect the current time constraints of the timeline. 

![image](https://cloud.githubusercontent.com/assets/373691/20435585/e5cbf96e-ad69-11e6-8d4d-ed30356f7240.png)
