### PR TITLE
show highlighted terms in event label

### DIFF
--- a/public/__tests__/kibi_timeline.js
+++ b/public/__tests__/kibi_timeline.js
@@ -1,3 +1,4 @@
+const sinon = require('auto-release-sinon');
 const angular = require('angular');
 const expect = require('expect.js');
 const _ = require('lodash');
@@ -45,6 +46,7 @@ describe('KibiTimeline Directive', function () {
     $elem = angular.element(directive);
     ngMock.inject(function (Private) {
       searchSource = Private(require('fixtures/stubbed_search_source'));
+      searchSource.highlight = sinon.stub();
     });
 
     const params = { endField, labelField, startField };

--- a/public/__tests__/kibi_timeline.js
+++ b/public/__tests__/kibi_timeline.js
@@ -10,6 +10,7 @@ require('plugins/kibi_timeline_vis/kibi_timeline_vis_controller');
 let $rootScope;
 let $scope;
 let searchSource;
+let highlightTags;
 
 let init = function ($elem, props) {
   ngMock.inject(function (_$rootScope_, $compile, _$timeout_) {
@@ -30,7 +31,7 @@ let destroy = function () {
 describe('KibiTimeline Directive', function () {
   let $elem;
 
-  function initTimeline({ withFieldSequence, endField, startField, labelField }) {
+  function initTimeline({ useHighlight = false, withFieldSequence, endField, startField, labelField }) {
     ngMock.module('kibana', $provide => {
       $provide.constant('kbnDefaultAppId', '');
       $provide.constant('kibiDefaultDashboardTitle', '');
@@ -44,12 +45,13 @@ describe('KibiTimeline Directive', function () {
                         options="options">
                       </kibi-timeline>`;
     $elem = angular.element(directive);
-    ngMock.inject(function (Private) {
+    ngMock.inject(function (_highlightTags_, Private) {
+      highlightTags = _highlightTags_;
       searchSource = Private(require('fixtures/stubbed_search_source'));
       searchSource.highlight = sinon.stub();
     });
 
-    const params = { endField, labelField, startField };
+    const params = { useHighlight, endField, labelField, startField };
     if (withFieldSequence) {
       params.startFieldSequence = startField.split('.');
       params.endFieldSequence = endField.split('.');
@@ -82,7 +84,7 @@ describe('KibiTimeline Directive', function () {
     expect($elem.text()).to.not.be.empty();
   });
 
-  it('should correcty return a timeline', function () {
+  it('should correctly return a timeline', function () {
     initTimeline({
       startField: '@timestamp',
       endField: '',
@@ -125,6 +127,63 @@ describe('KibiTimeline Directive', function () {
     $scope.$digest();
     expect($scope.timeline.itemsData.length).to.be(1);
     $scope.timeline.itemsData.forEach(data => {
+      sinon.assert.notCalled(searchSource.highlight);
+      expect(data.value).to.be('linux');
+      expect(data.start.valueOf()).to.be(dateObj.valueOf());
+    });
+  });
+
+  it('should get the highlighted terms of events if useHighlight is true', function () {
+    initTimeline({
+      useHighlight: true,
+      startField: '@timestamp',
+      endField: '',
+      labelField: 'machine.os'
+    });
+
+    const date = '25-01-1995';
+    const dateObj = moment(date, 'DD-MM-YYYY');
+    const results = {
+      took: 73,
+      timed_out: false,
+      _shards: {
+        total: 144,
+        successful: 144,
+        failed: 0
+      },
+      hits: {
+        total : 49487,
+        max_score : 1.0,
+        hits: [
+          {
+            _index: 'logstash-2014.09.09',
+            _type: 'apache',
+            _id: '61',
+            _score: 1,
+            _source: {
+              '@timestamp': date,
+              machine: {
+                os: 'linux'
+              }
+            },
+            fields: {
+              '@timestamp': [ dateObj ]
+            },
+            highlight: {
+              'machine.os': [
+                `${highlightTags.pre}BEST BEST${highlightTags.post}`
+              ]
+            }
+          }
+        ]
+      }
+    };
+    searchSource.crankResults(results);
+    $scope.$digest();
+    expect($scope.timeline.itemsData.length).to.be(1);
+    $scope.timeline.itemsData.forEach(data => {
+      sinon.assert.called(searchSource.highlight);
+      expect(data.content).to.match(/best best/);
       expect(data.value).to.be('linux');
       expect(data.start.valueOf()).to.be(dateObj.valueOf());
     });
@@ -171,6 +230,7 @@ describe('KibiTimeline Directive', function () {
       $scope.$digest();
       expect($scope.timeline.itemsData.length).to.be(1);
       $scope.timeline.itemsData.forEach(data => {
+        sinon.assert.notCalled(searchSource.highlight);
         expect(data.value).to.be('N/A');
         expect(data.start.valueOf()).to.be(dateObj.valueOf());
       });

--- a/public/kibi_timeline.js
+++ b/public/kibi_timeline.js
@@ -160,17 +160,19 @@ define(function (require) {
           config.set(NUM_FRAGS_CONFIG, DEFAULT_NUM_FRAGS);
         }
 
-        searchSource.highlight({
-          pre_tags: [highlightTags.pre],
-          post_tags: [highlightTags.post],
-          fields: {
-            '*': {
-              fragment_size: 0,
-              number_of_fragments: numFrags
-            }
-          },
-          require_field_match: false
-        });
+        if (params.useHighlight) {
+          searchSource.highlight({
+            pre_tags: [highlightTags.pre],
+            post_tags: [highlightTags.post],
+            fields: {
+              '*': {
+                fragment_size: 0,
+                number_of_fragments: numFrags
+              }
+            },
+            require_field_match: false
+          });
+        }
 
         searchSource.onResults().then(function onResults(searchResp) {
           let events = [];

--- a/public/kibi_timeline.js
+++ b/public/kibi_timeline.js
@@ -1,9 +1,11 @@
 define(function (require) {
+  require('ui/highlight/highlight_tags');
   let _ = require('lodash');
   let vis = require('vis');
   let buildRangeFilter = require('ui/filter_manager/lib/range');
 
-  require('ui/modules').get('kibana').directive('kibiTimeline', function (Private, createNotifier, courier, indexPatterns, config) {
+  require('ui/modules').get('kibana').directive('kibiTimeline',
+  function (Private, createNotifier, courier, indexPatterns, config, highlightTags) {
     const kibiUtils = require('kibiutils');
     let requestQueue = Private(require('./lib/courier/_request_queue_wrapped'));
     let timelineHelper = Private(require('./lib/helpers/timeline_helper'));
@@ -150,6 +152,8 @@ define(function (require) {
         const groupColor = group.color;
 
         searchSource.highlight({
+          pre_tags: [highlightTags.pre],
+          post_tags: [highlightTags.post],
           fields: {
             '*': {
               fragment_size: 0,
@@ -193,7 +197,7 @@ define(function (require) {
                   ', startField: ' + params.startField +
                   (params.endField ? ', endField: ' + params.endField : '') +
                   '">' + labelValue +
-                  (params.useHighlight ? '<p class="tiny-txt">' + timelineHelper.pluckHighlights(hit) + '</p>' : '') +
+                  (params.useHighlight ? '<p class="tiny-txt">' + timelineHelper.pluckHighlights(hit, highlightTags) + '</p>' : '') +
                   '</div>';
 
                 let e =  {

--- a/public/kibi_timeline.js
+++ b/public/kibi_timeline.js
@@ -192,7 +192,9 @@ define(function (require) {
                   '<div title="index: ' + indexId +
                   ', startField: ' + params.startField +
                   (params.endField ? ', endField: ' + params.endField : '') +
-                  '">' + labelValue + '</div>';
+                  '">' + labelValue +
+                  (params.useHighlight ? '<p class="tiny-txt">' + timelineHelper.pluckHighlights(hit) + '</p>' : '') +
+                  '</div>';
 
                 let e =  {
                   index: indexId,

--- a/public/kibi_timeline.js
+++ b/public/kibi_timeline.js
@@ -149,6 +149,16 @@ define(function (require) {
         const groupId = group.id;
         const groupColor = group.color;
 
+        searchSource.highlight({
+          fields: {
+            '*': {
+              fragment_size: 0,
+              number_of_fragments: 100
+            }
+          },
+          require_field_match: false
+        });
+
         searchSource.onResults().then(function onResults(searchResp) {
           let events = [];
 
@@ -163,11 +173,7 @@ define(function (require) {
             let endRawFieldValue;
 
             _.each(searchResp.hits.hits, function (hit) {
-              if (params.labelFieldSequence) { // in kibi, we have the path property of a field
-                labelFieldValue = kibiUtils.getValuesAtPath(hit._source, params.labelFieldSequence);
-              } else {
-                labelFieldValue = _.get(hit._source, params.labelField);
-              }
+              labelFieldValue = timelineHelper.pluckLabel(hit, params);
               if (params.startFieldSequence) { // in kibi, we have the path property of a field
                 startFieldValue = kibiUtils.getValuesAtPath(hit._source, params.startFieldSequence);
               } else {

--- a/public/kibi_timeline.js
+++ b/public/kibi_timeline.js
@@ -163,17 +163,15 @@ define(function (require) {
           let events = [];
 
           if (params.startField) {
-            let detectedMultivaluedLabel;
             let detectedMultivaluedStart;
             let detectedMultivaluedEnd;
-            let labelFieldValue;
             let startFieldValue;
             let startRawFieldValue;
             let endFieldValue;
             let endRawFieldValue;
 
             _.each(searchResp.hits.hits, function (hit) {
-              labelFieldValue = timelineHelper.pluckLabel(hit, params);
+              let labelValue = timelineHelper.pluckLabel(hit, params, notify);
               if (params.startFieldSequence) { // in kibi, we have the path property of a field
                 startFieldValue = kibiUtils.getValuesAtPath(hit._source, params.startFieldSequence);
               } else {
@@ -187,13 +185,9 @@ define(function (require) {
                 if (timelineHelper.isMultivalued(startFieldValue)) {
                   detectedMultivaluedStart = true;
                 }
-                if (timelineHelper.isMultivalued(labelFieldValue)) {
-                  detectedMultivaluedLabel = true;
-                }
                 let indexId = searchSource.get('index').id;
                 let startValue = timelineHelper.pickFirstIfMultivalued(startFieldValue);
                 let startRawValue = timelineHelper.pickFirstIfMultivalued(startRawFieldValue);
-                let labelValue = timelineHelper.pickFirstIfMultivalued(labelFieldValue, 'N/A');
                 let content =
                   '<div title="index: ' + indexId +
                   ', startField: ' + params.startField +
@@ -255,9 +249,6 @@ define(function (require) {
               }
             });
 
-            if (detectedMultivaluedLabel) {
-              notify.warning('Label field [' + params.labelField + '] is multivalued - the first value will be used.');
-            }
             if (detectedMultivaluedStart) {
               notify.warning('Start Date field [' + params.startField + '] is multivalued - the first date will be used.');
             }

--- a/public/kibi_timeline.js
+++ b/public/kibi_timeline.js
@@ -7,6 +7,8 @@ define(function (require) {
   require('ui/modules').get('kibana').directive('kibiTimeline',
   function (Private, createNotifier, courier, indexPatterns, config, highlightTags) {
     const kibiUtils = require('kibiutils');
+    const NUM_FRAGS_CONFIG = 'kibi:timeline:highlight:number_of_fragments';
+    const DEFAULT_NUM_FRAGS = 25;
     let requestQueue = Private(require('./lib/courier/_request_queue_wrapped'));
     let timelineHelper = Private(require('./lib/helpers/timeline_helper'));
 
@@ -151,13 +153,20 @@ define(function (require) {
         const groupId = group.id;
         const groupColor = group.color;
 
+        let numFrags = parseInt(config.get(NUM_FRAGS_CONFIG, NaN), 10);
+        //(numFrags !== numFrags) is required instead of (numFrags === NaN) because NaN does not equals itself!
+        if (numFrags !== numFrags || numFrags < 0) {
+          numFrags = DEFAULT_NUM_FRAGS;
+          config.set(NUM_FRAGS_CONFIG, DEFAULT_NUM_FRAGS);
+        }
+
         searchSource.highlight({
           pre_tags: [highlightTags.pre],
           post_tags: [highlightTags.post],
           fields: {
             '*': {
               fragment_size: 0,
-              number_of_fragments: 100
+              number_of_fragments: numFrags
             }
           },
           require_field_match: false

--- a/public/kibi_timeline_vis.less
+++ b/public/kibi_timeline_vis.less
@@ -10,7 +10,7 @@
 
   .tiny-txt {
     font-size: 0.8em;
-    margin: 0px;
+    margin: 0;
   }
 }
 

--- a/public/kibi_timeline_vis.less
+++ b/public/kibi_timeline_vis.less
@@ -58,3 +58,8 @@
   box-shadow: none!important; /* disable the shadow */
 }
 
+.tiny-txt {
+  font-size: 0.8em;
+  margin: 0px;
+}
+

--- a/public/kibi_timeline_vis.less
+++ b/public/kibi_timeline_vis.less
@@ -7,6 +7,11 @@
   .vis-item{
     cursor: pointer;
   }
+
+  .tiny-txt {
+    font-size: 0.8em;
+    margin: 0px;
+  }
 }
 
 .kibi-timeline-vis-params{
@@ -57,9 +62,3 @@
 .vis-panel .vis-shadow {
   box-shadow: none!important; /* disable the shadow */
 }
-
-.tiny-txt {
-  font-size: 0.8em;
-  margin: 0px;
-}
-

--- a/public/kibi_timeline_vis_controller.js
+++ b/public/kibi_timeline_vis_controller.js
@@ -80,13 +80,16 @@ define(function (require) {
                 label: group.groupLabel,
                 searchSource: searchSource,
                 params: {
+                  //kibi params
                   labelFieldSequence: fields[i].byName[group.labelField].path,
                   startFieldSequence: fields[i].byName[group.startField].path,
                   endFieldSequence: group.endField && fields[i].byName[group.endField].path || [],
-
+                  //kibana params
                   labelField: group.labelField,
                   startField: group.startField,
-                  endField: group.endField
+                  endField: group.endField,
+                  //params for both
+                  useHighlight: group.useHighlight
                 }
               });
             }

--- a/public/kibi_timeline_vis_params.html
+++ b/public/kibi_timeline_vis_params.html
@@ -26,6 +26,15 @@
 
           <div class="form-group">
             <label>Event label</label>
+            <div>
+             <label>
+              <input type="checkbox"
+                name="useHighlight"
+                ng-model="group.useHighlight">
+                Show highlighted terms
+                <kbn-info info="Show highlighted terms in event label."></kbn-info>
+             </label>
+            </div>
             <kibi-select-port required object-type="field" index-pattern-id="group.indexPatternId" ng-model="group.labelField">
             </kibi-select-port>
           </div>

--- a/public/lib/helpers/timeline_helper.js
+++ b/public/lib/helpers/timeline_helper.js
@@ -32,7 +32,7 @@ define(function (require) {
     };
 
     TimelineHelper.prototype.pluckLabel = function (hit, params, notify) {
-      let label = '';
+      let label = 'N/A';
 
       let field;
       if (params.labelFieldSequence) { // in kibi, we have the path property of a field
@@ -40,11 +40,11 @@ define(function (require) {
       } else {
         field = _.get(hit._source, params.labelField);
       }
-      if (field) {
+      if (field && (!_.isArray(field) || field.length)) {
         if (this.isMultivalued(field)) {
           notify.warning('Label field [' + params.labelField + '] is multivalued - the first value will be used.');
         }
-        label = this.pickFirstIfMultivalued(field, '');
+        label = this.pickFirstIfMultivalued(field, 'N/A');
       }
       return label;
     };
@@ -75,7 +75,7 @@ define(function (require) {
         return counts[a] < counts[b];
       }).forEach(function (key, index) {
         if (index > 0) highlighted += ', ';
-        highlighted += key + ':' + counts[key];
+        highlighted += `${key}: ${counts[key]}`;
       });
       return highlighted;
     };

--- a/public/lib/helpers/timeline_helper.js
+++ b/public/lib/helpers/timeline_helper.js
@@ -49,12 +49,12 @@ define(function (require) {
       return label;
     };
 
-    TimelineHelper.prototype.pluckHighlights = function (hit) {
+    TimelineHelper.prototype.pluckHighlights = function (hit, highlightTags) {
       //Track unique highlights, count number of times highlight occurs.
       const counts = {}; //key is highlight tag, value is count
       Object.keys(hit.highlight).forEach(function (key) {
         hit.highlight[key].forEach(function (it) {
-          const fragment = extractFragment(it, '<em>', '</em>');
+          const fragment = extractFragment(it, highlightTags.pre, highlightTags.post);
           if (counts[fragment]) {
             counts[fragment] = counts[fragment] + 1;
           } else {

--- a/public/lib/helpers/timeline_helper.js
+++ b/public/lib/helpers/timeline_helper.js
@@ -75,7 +75,7 @@ define(function (require) {
         return counts.get(a) < counts.get(b);
       }).forEach(function (key, index) {
         if (index > 0) highlighted += ', ';
-        highlighted += `${key}: ${counts[key]}`;
+        highlighted += `${key}: ${counts.get(key)}`;
       });
       return highlighted;
     };

--- a/public/lib/helpers/timeline_helper.js
+++ b/public/lib/helpers/timeline_helper.js
@@ -31,13 +31,20 @@ define(function (require) {
       }
     };
 
-    TimelineHelper.prototype.pluckLabel = function (hit, params) {
+    TimelineHelper.prototype.pluckLabel = function (hit, params, notify) {
       let label = '';
 
+      let field;
       if (params.labelFieldSequence) { // in kibi, we have the path property of a field
-        label = kibiUtils.getValuesAtPath(hit._source, params.labelFieldSequence);
+        field = kibiUtils.getValuesAtPath(hit._source, params.labelFieldSequence);
       } else {
-        label = _.get(hit._source, params.labelField);
+        field = _.get(hit._source, params.labelField);
+      }
+      if (field) {
+        if (this.isMultivalued(field)) {
+          notify.warning('Label field [' + params.labelField + '] is multivalued - the first value will be used.');
+        }
+        label = this.pickFirstIfMultivalued(field, '');
       }
 
       if (params.useHighlight) {

--- a/public/lib/helpers/timeline_helper.js
+++ b/public/lib/helpers/timeline_helper.js
@@ -1,4 +1,6 @@
 define(function (require) {
+  let _ = require('lodash');
+  const kibiUtils = require('kibiutils');
   const moment = require('moment');
 
   return function TimelineHelperFactory() {
@@ -28,6 +30,53 @@ define(function (require) {
         return timezone;
       }
     };
+
+    TimelineHelper.prototype.pluckLabel = function (hit, params) {
+      let label = '';
+
+      if (params.labelFieldSequence) { // in kibi, we have the path property of a field
+        label = kibiUtils.getValuesAtPath(hit._source, params.labelFieldSequence);
+      } else {
+        label = _.get(hit._source, params.labelField);
+      }
+
+      if (params.useHighlight) {
+        const fragmentCounts = {}; //key is fragment tag, value is count
+        Object.keys(hit.highlight).forEach(function (key) {
+          hit.highlight[key].forEach(function (it) {
+            const fragment = extractFragment(it, '<em>', '</em>');
+            if (fragmentCounts[fragment]) {
+              fragmentCounts[fragment] = fragmentCounts[fragment] + 1;
+            } else {
+              fragmentCounts[fragment] = 1;
+            }
+          });
+        });
+
+        let highlighted = '';
+        Object.keys(fragmentCounts).sort(function (a, b) {
+          //same count, return alphabetic order
+          if (fragmentCounts[a] === fragmentCounts[b]) {
+            return a > b;
+          }
+
+          //return count order
+          return fragmentCounts[a] < fragmentCounts[b];
+
+        }).forEach(function (key, index) {
+          if (index > 0) highlighted += ', ';
+          highlighted += key + ':' + fragmentCounts[key];
+        });
+        label += '<div style="font-size: small">' + highlighted + '</div>';
+      }
+      return label;
+    };
+
+    function extractFragment(s, openTag, closeTag) {
+      const openIndex = s.indexOf(openTag);
+      const closeIndex = s.indexOf(closeTag);
+      return s.substring(openIndex + openTag.length, closeIndex).toLowerCase().trim();
+    }
 
     return new TimelineHelper();
   };

--- a/public/lib/helpers/timeline_helper.js
+++ b/public/lib/helpers/timeline_helper.js
@@ -31,6 +31,14 @@ define(function (require) {
       }
     };
 
+    /**
+     * pluckLabel returns the label of an event
+     *
+     * @param hit the document of the event
+     * @param params configuration parameters for the event
+     * @param notify object for user notification
+     * @returns the label as a string
+     */
     TimelineHelper.prototype.pluckLabel = function (hit, params, notify) {
       let label = 'N/A';
 
@@ -49,8 +57,18 @@ define(function (require) {
       return label;
     };
 
+    /**
+     * pluckHighlights returns the highlighted terms for the event.
+     * The terms are sorted first on the number of occurrences of a term, and then alphabetically.
+     *
+     * @param hit the event
+     * @param highlightTags the tags that wrap the term
+     * @returns a comma-separated string of the highlighted terms and their number of occurrences
+     */
     TimelineHelper.prototype.pluckHighlights = function (hit, highlightTags) {
-      if (!hit.highlight) return '';
+      if (!hit.highlight) {
+        return '';
+      }
 
       //Track unique highlights, count number of times highlight occurs.
       const counts = new Map(); //key is highlight tag, value is count
@@ -65,25 +83,23 @@ define(function (require) {
         });
       });
 
-      let highlighted = '';
-      Array.from(counts.keys()).sort(function (a, b) {
+      return Array.from(counts.keys())
+      .sort(function (a, b) {
         //same count, return alphabetic order
         if (counts.get(a) === counts.get(b)) {
           return a > b;
         }
         //return count order
         return counts.get(a) < counts.get(b);
-      }).forEach(function (key, index) {
-        if (index > 0) highlighted += ', ';
-        highlighted += `${key}: ${counts.get(key)}`;
-      });
-      return highlighted;
+      })
+      .map(key => `${key}: ${counts.get(key)}`)
+      .join(', ');
     };
 
-    function extractFragment(s, openTag, closeTag) {
-      const openIndex = s.indexOf(openTag);
-      const closeIndex = s.indexOf(closeTag);
-      return s.substring(openIndex + openTag.length, closeIndex).toLowerCase().trim();
+    function extractFragment(highlightedElement, openTag, closeTag) {
+      const openIndex = highlightedElement.indexOf(openTag);
+      const closeIndex = highlightedElement.indexOf(closeTag);
+      return highlightedElement.substring(openIndex + openTag.length, closeIndex).toLowerCase().trim();
     }
 
     return new TimelineHelper();

--- a/public/lib/helpers/timeline_helper.js
+++ b/public/lib/helpers/timeline_helper.js
@@ -50,6 +50,8 @@ define(function (require) {
     };
 
     TimelineHelper.prototype.pluckHighlights = function (hit, highlightTags) {
+      if (!hit.highlight) return '';
+
       //Track unique highlights, count number of times highlight occurs.
       const counts = {}; //key is highlight tag, value is count
       Object.keys(hit.highlight).forEach(function (key) {

--- a/public/lib/helpers/timeline_helper.js
+++ b/public/lib/helpers/timeline_helper.js
@@ -53,26 +53,26 @@ define(function (require) {
       if (!hit.highlight) return '';
 
       //Track unique highlights, count number of times highlight occurs.
-      const counts = {}; //key is highlight tag, value is count
+      const counts = new Map(); //key is highlight tag, value is count
       Object.keys(hit.highlight).forEach(function (key) {
         hit.highlight[key].forEach(function (it) {
           const fragment = extractFragment(it, highlightTags.pre, highlightTags.post);
-          if (counts[fragment]) {
-            counts[fragment] = counts[fragment] + 1;
+          if (counts.has(fragment)) {
+            counts.set(fragment, counts.get(fragment) + 1);
           } else {
-            counts[fragment] = 1;
+            counts.set(fragment, 1);
           }
         });
       });
 
       let highlighted = '';
-      Object.keys(counts).sort(function (a, b) {
+      Array.from(counts.keys()).sort(function (a, b) {
         //same count, return alphabetic order
-        if (counts[a] === counts[b]) {
+        if (counts.get(a) === counts.get(b)) {
           return a > b;
         }
         //return count order
-        return counts[a] < counts[b];
+        return counts.get(a) < counts.get(b);
       }).forEach(function (key, index) {
         if (index > 0) highlighted += ', ';
         highlighted += `${key}: ${counts[key]}`;

--- a/public/lib/helpers/timeline_helper.js
+++ b/public/lib/helpers/timeline_helper.js
@@ -46,37 +46,36 @@ define(function (require) {
         }
         label = this.pickFirstIfMultivalued(field, '');
       }
-
-      if (params.useHighlight) {
-        const fragmentCounts = {}; //key is fragment tag, value is count
-        Object.keys(hit.highlight).forEach(function (key) {
-          hit.highlight[key].forEach(function (it) {
-            const fragment = extractFragment(it, '<em>', '</em>');
-            if (fragmentCounts[fragment]) {
-              fragmentCounts[fragment] = fragmentCounts[fragment] + 1;
-            } else {
-              fragmentCounts[fragment] = 1;
-            }
-          });
-        });
-
-        let highlighted = '';
-        Object.keys(fragmentCounts).sort(function (a, b) {
-          //same count, return alphabetic order
-          if (fragmentCounts[a] === fragmentCounts[b]) {
-            return a > b;
-          }
-
-          //return count order
-          return fragmentCounts[a] < fragmentCounts[b];
-
-        }).forEach(function (key, index) {
-          if (index > 0) highlighted += ', ';
-          highlighted += key + ':' + fragmentCounts[key];
-        });
-        label += '<div style="font-size: small">' + highlighted + '</div>';
-      }
       return label;
+    };
+
+    TimelineHelper.prototype.pluckHighlights = function (hit) {
+      //Track unique highlights, count number of times highlight occurs.
+      const counts = {}; //key is highlight tag, value is count
+      Object.keys(hit.highlight).forEach(function (key) {
+        hit.highlight[key].forEach(function (it) {
+          const fragment = extractFragment(it, '<em>', '</em>');
+          if (counts[fragment]) {
+            counts[fragment] = counts[fragment] + 1;
+          } else {
+            counts[fragment] = 1;
+          }
+        });
+      });
+
+      let highlighted = '';
+      Object.keys(counts).sort(function (a, b) {
+        //same count, return alphabetic order
+        if (counts[a] === counts[b]) {
+          return a > b;
+        }
+        //return count order
+        return counts[a] < counts[b];
+      }).forEach(function (key, index) {
+        if (index > 0) highlighted += ', ';
+        highlighted += key + ':' + counts[key];
+      });
+      return highlighted;
     };
 
     function extractFragment(s, openTag, closeTag) {


### PR DESCRIPTION
Using an `event label` field containing large amounts of text does not display very well. The event label is just a super long string of text. This pull request gives the user the option to show the highlighted terms returned from the saved search in the event label. That way, the relevant bits of data from large text strings are visible without all of the clutter.