### PR TITLE
No bubbles displayed if only start date exist.

### DIFF
--- a/public/__tests__/kibi_timeline.js
+++ b/public/__tests__/kibi_timeline.js
@@ -381,23 +381,23 @@ describe('KibiTimeline Directive', function () {
         case 0:
           expect(data.value).to.be('linux');
           expect(data.start.valueOf()).to.be(date1Obj.valueOf());
-          // color is inverted
+          // emphasized, border style is solid
           expect(data.style).to.match(/color: #ff0000/);
-          expect(data.style).to.match(/background-color: #fff/);
+          expect(data.style).to.match(/border-style: solid/);
           break;
         case 1:
           expect(data.value).to.be('mac');
           expect(data.start.valueOf()).to.be(date2Obj.valueOf());
-          // color is inverted
+          // emphasized, border style is solid
           expect(data.style).to.match(/color: #ff0000/);
-          expect(data.style).to.match(/background-color: #fff/);
+          expect(data.style).to.match(/border-style: solid/);
           break;
         case 2:
           expect(data.value).to.be('linux');
           expect(data.start.valueOf()).to.be(date3Obj.valueOf());
-          // color is normal
-          expect(data.style).to.match(/color: #fff/);
-          expect(data.style).to.match(/background-color: #ff0000/);
+          // border style is none
+          expect(data.style).to.match(/color: #ff0000/);
+          expect(data.style).to.match(/border-style: none/);
           break;
         default:
           expect().fail(`Should not have the case itemIndex=${itemIndex}`);

--- a/public/kibi_timeline.js
+++ b/public/kibi_timeline.js
@@ -1,11 +1,13 @@
+/* global angular */
 define(function (require) {
   require('ui/highlight/highlight_tags');
+  const itemTemplate = require('./kibi_timeline_item.html');
   const _ = require('lodash');
   const vis = require('vis');
   const buildRangeFilter = require('ui/filter_manager/lib/range');
 
   require('ui/modules').get('kibana').directive('kibiTimeline',
-  function (Private, createNotifier, courier, indexPatterns, config, highlightTags, timefilter) {
+  function (Private, createNotifier, courier, indexPatterns, config, highlightTags, timefilter, $compile, $interpolate) {
     const kibiUtils = require('kibiutils');
     const NUM_FRAGS_CONFIG = 'kibi:timeline:highlight:number_of_fragments';
     const DEFAULT_NUM_FRAGS = 25;
@@ -235,12 +237,24 @@ define(function (require) {
                   const startValue = value;
                   const startRawValue = startRawFieldValue[i];
 
-                  let content =
-                      '<div title="index: ' + indexId +
-                      ', startField: ' + params.startField +
-                      (params.endField ? ', endField: ' + params.endField : '') + '">' + labelValue +
-                      (params.useHighlight ? '<p class="tiny-txt">' + timelineHelper.pluckHighlights(hit, highlightTags) +
-                      '</p>' : '') + '</div>';
+                  //let content =
+                  //    '<div title="index: ' + indexId +
+                  //    ', startField: ' + params.startField +
+                  //    (params.endField ? ', endField: ' + params.endField : '') + '">' + labelValue +
+                  //    (params.useHighlight ? '<p class="tiny-txt">' + timelineHelper.pluckHighlights(hit, highlightTags) +
+                  //    '</p>' : '') + '</div>';
+                  const $itemscope = $scope.$new();
+                  $itemscope.contentDict = {
+                    indexId: indexId,
+                    startField: params.startField,
+                    endField: params.endField,
+                    labelValue: labelValue,
+                    useHighlight: params.useHighlight,
+                    highlight: timelineHelper.pluckHighlights(hit, highlightTags)
+                  };
+                  let content = $compile(itemTemplate)($itemscope)[0].innerHTML;
+                  console.log('INNER HTML:');
+                  console.log(content);
 
                   let style = `background-color: ${groupColor}; color: #fff;`;
                   if (!endFieldValue || startValue === endFieldValue[i]) {

--- a/public/kibi_timeline.js
+++ b/public/kibi_timeline.js
@@ -247,7 +247,7 @@ define(function (require) {
                     // here the end field value missing but expected
                     // or start field value === end field value
                     // force vis box look like vis point
-                    style = `border-style: none; background-color: #fff; color: ${groupColor};`;
+                    style = `border-style: none; background-color: #fff; color: ${groupColor}; border-color: ${groupColor}`;
                     const divregex = /(<div.*>)(.*)(<\/div>)/g;
                     const contentDivParts = divregex.exec(content);
                     const pointDot = '<div style="position:relative;padding:0;border-width:4px;border-style:solid;' +
@@ -259,7 +259,7 @@ define(function (require) {
                   if (params.invertFirstLabelInstance &&
                     !_.includes(uniqueLabels, labelValue.toLowerCase().trim())) {
                     if (!endFieldValue || startValue === endFieldValue[i]) {
-                      style = `border-style: solid; background-color: #fff; color: ${groupColor};`;
+                      style = `border-style: solid; background-color: #fff; color: ${groupColor}; border-color: ${groupColor}`;
                     } else {
                       style = `background-color: #fff; color: ${groupColor};`;
                     }

--- a/public/kibi_timeline.js
+++ b/public/kibi_timeline.js
@@ -1,13 +1,12 @@
 /* global angular */
 define(function (require) {
   require('ui/highlight/highlight_tags');
-  const itemTemplate = require('./kibi_timeline_item.html');
   const _ = require('lodash');
   const vis = require('vis');
   const buildRangeFilter = require('ui/filter_manager/lib/range');
 
   require('ui/modules').get('kibana').directive('kibiTimeline',
-  function (Private, createNotifier, courier, indexPatterns, config, highlightTags, timefilter, $compile, $interpolate) {
+  function (Private, createNotifier, courier, indexPatterns, config, highlightTags, timefilter) {
     const kibiUtils = require('kibiutils');
     const NUM_FRAGS_CONFIG = 'kibi:timeline:highlight:number_of_fragments';
     const DEFAULT_NUM_FRAGS = 25;
@@ -237,23 +236,19 @@ define(function (require) {
                   const startValue = value;
                   const startRawValue = startRawFieldValue[i];
 
-                  //let content =
-                  //    '<div title="index: ' + indexId +
-                  //    ', startField: ' + params.startField +
-                  //    (params.endField ? ', endField: ' + params.endField : '') + '">' + labelValue +
-                  //    (params.useHighlight ? '<p class="tiny-txt">' + timelineHelper.pluckHighlights(hit, highlightTags) +
-                  //    '</p>' : '') + '</div>';
-                  const $itemscope = $scope.$new();
-                  $itemscope.contentDict = {
+                  const itemDict = {
                     indexId: indexId,
                     startField: params.startField,
                     endField: params.endField,
                     labelValue: labelValue,
                     useHighlight: params.useHighlight,
-                    highlight: timelineHelper.pluckHighlights(hit, highlightTags)
+                    highlight: timelineHelper.pluckHighlights(hit, highlightTags),
+                    groupColor: groupColor,
+                    startValue: startValue,
+                    endFieldValue: endFieldValue
                   };
-                  let content = $compile(itemTemplate)($itemscope)[0].innerHTML;
-                  console.log('INNER HTML:');
+
+                  const content = timelineHelper.createItemTemplate(i, itemDict);
                   console.log(content);
 
                   let style = `background-color: ${groupColor}; color: #fff;`;
@@ -262,11 +257,6 @@ define(function (require) {
                     // or start field value === end field value
                     // force vis box look like vis point
                     style = `border-style: none; background-color: #fff; color: ${groupColor}; border-color: ${groupColor}`;
-                    const divregex = /(<div.*>)(.*)(<\/div>)/g;
-                    const contentDivParts = divregex.exec(content);
-                    const pointDot = `<div class="dot-item" style="border-color:${groupColor}"></div>`;
-                    const labelDiv = `<div class="label-item">${contentDivParts[2]}</div>`;
-                    content = contentDivParts[1] + pointDot + labelDiv + contentDivParts[3];
                   }
 
                   if (params.invertFirstLabelInstance &&

--- a/public/kibi_timeline.js
+++ b/public/kibi_timeline.js
@@ -249,7 +249,6 @@ define(function (require) {
                   };
 
                   const content = timelineHelper.createItemTemplate(i, itemDict);
-                  console.log(content);
 
                   let style = `background-color: ${groupColor}; color: #fff;`;
                   if (!endFieldValue || startValue === endFieldValue[i]) {

--- a/public/kibi_timeline.js
+++ b/public/kibi_timeline.js
@@ -245,10 +245,10 @@ define(function (require) {
                     highlight: timelineHelper.pluckHighlights(hit, highlightTags),
                     groupColor: groupColor,
                     startValue: startValue,
-                    endFieldValue: endFieldValue
+                    endFieldValue: endFieldValue ? endFieldValue[i] : null
                   };
 
-                  const content = timelineHelper.createItemTemplate(i, itemDict);
+                  const content = timelineHelper.createItemTemplate(itemDict);
 
                   let style = `background-color: ${groupColor}; color: #fff;`;
                   if (!endFieldValue || startValue === endFieldValue[i]) {

--- a/public/kibi_timeline.js
+++ b/public/kibi_timeline.js
@@ -264,35 +264,30 @@ define(function (require) {
                     groupId: groupId
                   };
 
-                  //debugger;
-                  //if (params.endField) {
                   if (!endFieldValue) {
                     // here the end field value missing but expected
                     // force the event to be of type point
                     e.style = 'border-style: none; background-color: #fff; color: #000;';
-                    let divregex = /(<div.*>)(.*)(<\/div>)/g;
-                    let contentParts = divregex.exec(e.content);
-                    let dot = '<div class="vis-item vis-dot vis-readonly" style="top: 10px; left: 4px;"></div>';
-                    let newContent = '<div style="margin-left: 15px">' + contentParts[2]  + '</div>';
+                    const divregex = /(<div.*>)(.*)(<\/div>)/g;
+                    const contentParts = divregex.exec(e.content);
+                    const dot = '<div class="vis-item vis-dot vis-readonly" style="top: 10px; left: 4px;"></div>';
+                    const newContent = '<div style="margin-left: 15px">' + contentParts[2]  + '</div>';
                     e.content = contentParts[1] + dot + newContent + contentParts[3];
                   } else {
-                    let endValue = endFieldValue[i];
-                    let endRawValue = endRawFieldValue[i];
+                    const endValue = endFieldValue[i];
+                    const endRawValue = endRawFieldValue[i];
                     if (startValue === endValue) {
                       // also force it to be a point
                       e.style = 'border-style: none; background-color: #fff; color: #000;';
-                      let divregex = /(<div.*>)(.*)(<\/div>)/g;
-                      let contentParts = divregex.exec(e.content);
-                      let dot = '<div class="vis-item vis-dot vis-readonly" style="top: 10px; left: 4px;"></div>';
-                      let newContent = '<div style="margin-left: 15px">' + contentParts[2]  + '</div>';
+                      const divregex = /(<div.*>)(.*)(<\/div>)/g;
+                      const contentParts = divregex.exec(e.content);
+                      const dot = '<div class="vis-item vis-dot vis-readonly" style="top: 10px; left: 4px;"></div>';
+                      const newContent = '<div style="margin-left: 15px">' + contentParts[2]  + '</div>';
                       e.content = contentParts[1] + dot + newContent + contentParts[3];
                     } else {
                       const endValue = endFieldValue[i];
                       const endRawValue = endRawFieldValue[i];
-                      if (startValue === endValue) {
-                        // also force it to be a point
-                        e.type = 'point';
-                      } else {
+                      if (startValue !== endValue) {
                         e.type = 'range';
                         e.end =  new Date(endRawValue);
                         e.endField = {
@@ -302,7 +297,6 @@ define(function (require) {
                       }
                     }
                   }
-                  //}
 
                   events.push(e);
 

--- a/public/kibi_timeline.js
+++ b/public/kibi_timeline.js
@@ -238,8 +238,7 @@ define(function (require) {
                   const content =
                       '<div title="index: ' + indexId +
                       ', startField: ' + params.startField +
-                      (params.endField ? ', endField: ' + params.endField : '') +
-                      '">' + labelValue +
+                      (params.endField ? ', endField: ' + params.endField : '') + '">' + labelValue +
                       (params.useHighlight ? '<p class="tiny-txt">' + timelineHelper.pluckHighlights(hit, highlightTags) +
                       '</p>' : '') + '</div>';
 
@@ -265,11 +264,28 @@ define(function (require) {
                     groupId: groupId
                   };
 
-                  if (params.endField) {
-                    if (!endFieldValue) {
-                      // here the end field value missing but expected
-                      // force the event to be of type point
-                      e.type = 'point';
+                  //debugger;
+                  //if (params.endField) {
+                  if (!endFieldValue) {
+                    // here the end field value missing but expected
+                    // force the event to be of type point
+                    e.style = 'border-style: none; background-color: #fff; color: #000;';
+                    let divregex = /(<div.*>)(.*)(<\/div>)/g;
+                    let contentParts = divregex.exec(e.content);
+                    let dot = '<div class="vis-item vis-dot vis-readonly" style="top: 10px; left: 4px;"></div>';
+                    let newContent = '<div style="margin-left: 15px">' + contentParts[2]  + '</div>';
+                    e.content = contentParts[1] + dot + newContent + contentParts[3];
+                  } else {
+                    let endValue = endFieldValue[i];
+                    let endRawValue = endRawFieldValue[i];
+                    if (startValue === endValue) {
+                      // also force it to be a point
+                      e.style = 'border-style: none; background-color: #fff; color: #000;';
+                      let divregex = /(<div.*>)(.*)(<\/div>)/g;
+                      let contentParts = divregex.exec(e.content);
+                      let dot = '<div class="vis-item vis-dot vis-readonly" style="top: 10px; left: 4px;"></div>';
+                      let newContent = '<div style="margin-left: 15px">' + contentParts[2]  + '</div>';
+                      e.content = contentParts[1] + dot + newContent + contentParts[3];
                     } else {
                       const endValue = endFieldValue[i];
                       const endRawValue = endRawFieldValue[i];
@@ -286,6 +302,7 @@ define(function (require) {
                       }
                     }
                   }
+                  //}
 
                   events.push(e);
 

--- a/public/kibi_timeline.js
+++ b/public/kibi_timeline.js
@@ -250,9 +250,8 @@ define(function (require) {
                     style = `border-style: none; background-color: #fff; color: ${groupColor}; border-color: ${groupColor}`;
                     const divregex = /(<div.*>)(.*)(<\/div>)/g;
                     const contentDivParts = divregex.exec(content);
-                    const pointDot = '<div style="position:relative;padding:0;border-width:4px;border-style:solid;' +
-                    'border-radius:4px;float:left;margin-top:6px;margin-right:4px;border-color:' + groupColor + '"></div>';
-                    const labelDiv = '<div style="margin-left: 15px">' + contentDivParts[2]  + '</div>';
+                    const pointDot = `<div class="dot-item" style="border-color:${groupColor}"></div>`;
+                    const labelDiv = `<div class="label-item">${contentDivParts[2]}</div>`;
                     content = contentDivParts[1] + pointDot + labelDiv + contentDivParts[3];
                   }
 

--- a/public/kibi_timeline.js
+++ b/public/kibi_timeline.js
@@ -1,4 +1,3 @@
-/* global angular */
 define(function (require) {
   require('ui/highlight/highlight_tags');
   const _ = require('lodash');

--- a/public/kibi_timeline_item.html
+++ b/public/kibi_timeline_item.html
@@ -1,0 +1,8 @@
+<div>
+<div ng-if="startField" title="index: {{indexId}}, startField: {{startField}} {{endField ? ', endField: endField' : ''}}">
+{{labelValue}}
+<p ng-if="useHighlight" class="tiny-txt">{{highlight}}</p>
+</div>
+<div ng-show="contentDict.labelValue == 'Fuselage'">Fuselage</div>
+<div ng-show="contentDict.labelValue != 'Fuselage'">Without Fuselage</div>
+</div>

--- a/public/kibi_timeline_item.html
+++ b/public/kibi_timeline_item.html
@@ -1,8 +1,0 @@
-<div>
-<div ng-if="startField" title="index: {{indexId}}, startField: {{startField}} {{endField ? ', endField: endField' : ''}}">
-{{labelValue}}
-<p ng-if="useHighlight" class="tiny-txt">{{highlight}}</p>
-</div>
-<div ng-show="contentDict.labelValue == 'Fuselage'">Fuselage</div>
-<div ng-show="contentDict.labelValue != 'Fuselage'">Without Fuselage</div>
-</div>

--- a/public/kibi_timeline_vis.less
+++ b/public/kibi_timeline_vis.less
@@ -63,7 +63,7 @@
   box-shadow: none!important; /* disable the shadow */
 }
 
-.dot-item {
+.kibi-tl-dot-item {
   position: relative;
   padding: 0;
   border-width: 4px;
@@ -75,6 +75,7 @@
   border-color: red;
 }
 
-.label-item {
+.kibi-tl-label-item {
   margin-left: 15px;
 }
+

--- a/public/kibi_timeline_vis.less
+++ b/public/kibi_timeline_vis.less
@@ -62,3 +62,19 @@
 .vis-panel .vis-shadow {
   box-shadow: none!important; /* disable the shadow */
 }
+
+.dot-item {
+  position: relative;
+  padding: 0;
+  border-width: 4px;
+  border-style: solid;
+  border-radius: 4px;
+  float: left;
+  margin-top: 6px;
+  margin-right: 4px;
+  border-color: red;
+}
+
+.label-item {
+  margin-left: 15px;
+}

--- a/public/kibi_timeline_vis_controller.js
+++ b/public/kibi_timeline_vis_controller.js
@@ -184,6 +184,15 @@ define(function (require) {
           removeVisStateChangedHandler();
         });
       }
-
+    })
+    .directive('kibiTimelineItem', function () {
+      return {
+        template: '<div>{{contentDict.labelValue}} {{contentDict.indexId}}</div>'
+        //link: function (scope, element) {
+        //  console.log('LINK:');
+        //  console.log(scope);
+        //  //element.append($compile('<div>{{contentDict.labelValue}} {{contentDict.indexId}}</div>')(scope));
+        //}
+      };
     });
 });

--- a/public/kibi_timeline_vis_controller.js
+++ b/public/kibi_timeline_vis_controller.js
@@ -184,15 +184,5 @@ define(function (require) {
           removeVisStateChangedHandler();
         });
       }
-    })
-    .directive('kibiTimelineItem', function () {
-      return {
-        template: '<div>{{contentDict.labelValue}} {{contentDict.indexId}}</div>'
-        //link: function (scope, element) {
-        //  console.log('LINK:');
-        //  console.log(scope);
-        //  //element.append($compile('<div>{{contentDict.labelValue}} {{contentDict.indexId}}</div>')(scope));
-        //}
-      };
     });
 });

--- a/public/lib/helpers/timeline_helper.js
+++ b/public/lib/helpers/timeline_helper.js
@@ -7,6 +7,16 @@ define(function (require) {
     function TimelineHelper() {
     }
 
+    TimelineHelper.prototype.createItemTemplate = function (i, itemDict) {
+      return '<div title="index: ' + itemDict.indexId + ', startField: ' + itemDict.startField +
+        (itemDict.endField ? ', endField: ' + itemDict.endField : '') + '">' +
+        (!itemDict.endFieldValue || itemDict.startValue === itemDict.endFieldValue[i]
+          ? '<div class="kibi-tl-dot-item" style="border-color:' + itemDict.groupColor + '"></div>' : '') +
+        (!itemDict.endFieldValue || itemDict.startValue === itemDict.endFieldValue[i]
+          ? '<div class="kibi-tl-label-item">' + itemDict.labelValue + '</div>' : itemDict.labelValue) +
+        (itemDict.useHighlight ? '<p class="tiny-txt">' + itemDict.highlight + '</p>' : '') + '</div>';
+    };
+
     TimelineHelper.prototype.changeTimezone  = function (timezone) {
       if (timezone !== 'Browser') {
         return moment().tz(timezone).format('Z');

--- a/public/lib/helpers/timeline_helper.js
+++ b/public/lib/helpers/timeline_helper.js
@@ -7,12 +7,12 @@ define(function (require) {
     function TimelineHelper() {
     }
 
-    TimelineHelper.prototype.createItemTemplate = function (i, itemDict) {
+    TimelineHelper.prototype.createItemTemplate = function (itemDict) {
       return '<div title="index: ' + itemDict.indexId + ', startField: ' + itemDict.startField +
         (itemDict.endField ? ', endField: ' + itemDict.endField : '') + '">' +
-        (!itemDict.endFieldValue || itemDict.startValue === itemDict.endFieldValue[i]
+        (!itemDict.endFieldValue || itemDict.startValue === itemDict.endFieldValue
           ? '<div class="kibi-tl-dot-item" style="border-color:' + itemDict.groupColor + '"></div>' : '') +
-        (!itemDict.endFieldValue || itemDict.startValue === itemDict.endFieldValue[i]
+        (!itemDict.endFieldValue || itemDict.startValue === itemDict.endFieldValue
           ? '<div class="kibi-tl-label-item">' + itemDict.labelValue + '</div>' : itemDict.labelValue) +
         (itemDict.useHighlight ? '<p class="tiny-txt">' + itemDict.highlight + '</p>' : '') + '</div>';
     };

--- a/public/lib/helpers/timeline_helper.js
+++ b/public/lib/helpers/timeline_helper.js
@@ -14,8 +14,8 @@ define(function (require) {
     TimelineHelper.prototype.createItemTemplate = function (itemDict) {
       let endfield = '';
       let dot = '';
-      let label = '';
       let hilit = '';
+      let label = itemDict.labelValue;
 
       if (itemDict.endField) {
         endfield = `, endField: ${itemDict.endField}`;
@@ -28,7 +28,7 @@ define(function (require) {
         hilit = `<p class="tiny-txt">${itemDict.highlight}</p>`;
       }
 
-      return `<div title="index: ${itemDict.indexId}, startField: ${itemDict.startField} ${endfield}">` +
+      return `<div title="index: ${itemDict.indexId}, startField: ${itemDict.startField}${endfield}">` +
           `${dot}${label}${hilit}</div>`;
     };
 

--- a/public/lib/helpers/timeline_helper.js
+++ b/public/lib/helpers/timeline_helper.js
@@ -7,14 +7,29 @@ define(function (require) {
     function TimelineHelper() {
     }
 
+    TimelineHelper.prototype.noEndOrEqual = function (startValue, endValue) {
+      return !endValue || startValue === endValue ? true : false;
+    };
+
     TimelineHelper.prototype.createItemTemplate = function (itemDict) {
-      return '<div title="index: ' + itemDict.indexId + ', startField: ' + itemDict.startField +
-        (itemDict.endField ? ', endField: ' + itemDict.endField : '') + '">' +
-        (!itemDict.endFieldValue || itemDict.startValue === itemDict.endFieldValue
-          ? '<div class="kibi-tl-dot-item" style="border-color:' + itemDict.groupColor + '"></div>' : '') +
-        (!itemDict.endFieldValue || itemDict.startValue === itemDict.endFieldValue
-          ? '<div class="kibi-tl-label-item">' + itemDict.labelValue + '</div>' : itemDict.labelValue) +
-        (itemDict.useHighlight ? '<p class="tiny-txt">' + itemDict.highlight + '</p>' : '') + '</div>';
+      let endfield = '';
+      let dot = '';
+      let label = '';
+      let hilit = '';
+
+      if (itemDict.endField) {
+        endfield = `, endField: ${itemDict.endField}`;
+      }
+      if (this.noEndOrEqual(itemDict.startValue, itemDict.endValue)) {
+        dot = `<div class="kibi-tl-dot-item" style="border-color:${itemDict.groupColor}"></div>`;
+        label = `<div class="kibi-tl-label-item">${itemDict.labelValue}</div>`;
+      }
+      if (itemDict.useHighlight) {
+        hilit = `<p class="tiny-txt">${itemDict.highlight}</p>`;
+      }
+
+      return `<div title="index: ${itemDict.indexId}, startField: ${itemDict.startField} ${endfield}">` +
+          `${dot}${label}${hilit}</div>`;
     };
 
     TimelineHelper.prototype.changeTimezone  = function (timezone) {


### PR DESCRIPTION
Issue #89 
I added the dots by manually manipulating HTML and style. Now it looks exactly like it is in [our docs](https://docs.siren.solutions/kibi/community/4.5.4/#timeline):
![screenshot from 2016-12-19 12-16-20](https://cloud.githubusercontent.com/assets/5389745/21311114/d34e4e38-c5e5-11e6-8053-2771dbf4d1ec.png)

I haven't found a way to do it purely with vis.js. The library doesn't display relations to the X axis when `e.type: 'point'` is used as an event property. In short words, I got the visualization similar to this http://visjs.org/examples/timeline/items/pointItems.html

Other examples: 
http://visjs.org/examples/timeline/items/backgroundAreasWithGroups.html
http://visjs.org/examples/timeline/dataHandling/dataSerialization.html
http://visjs.org/examples/timeline/dataHandling/loadExternalData.html
http://visjs.org/examples/timeline/editing/editingItems.html

Seems like `e.type: point` is designed to not place relations to the X axis.
I can go and fix it in the library.