### PR TITLE
New. Add support of Elasticsearch multivalued fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This plugin can be installed in both:
 ### Automatic
 
 ```sh
-$ ./bin/kibi plugin -i kibi_timeline_vis -u https://github.com/sirensolutions/kibi_timeline_vis/raw/4.5.3/target/kibi_timeline_vis-4.5.3.zip
+$ ./bin/kibi plugin -i kibi_timeline_vis -u https://github.com/sirensolutions/kibi_timeline_vis/raw/4.5.4/target/kibi_timeline_vis-4.5.4.zip
 ```
 
 ### Manual    
@@ -27,7 +27,7 @@ $ cd kibi_timeline_vis
 $ npm install
 $ npm run build
 $ gulp package
-$ unzip target/kibi_timeline_vis-4.5.3.zip -d KIBANA_FOLDER_PATH/installedPlugins/
+$ unzip target/kibi_timeline_vis-4.5.4.zip -d KIBANA_FOLDER_PATH/installedPlugins/
 ```
 
 ## Uninstall

--- a/examples/create_index_and_insert_docs.js
+++ b/examples/create_index_and_insert_docs.js
@@ -1,0 +1,124 @@
+'use strict';
+
+var elasticsearch = require('elasticsearch');
+var format = require('string-template');
+
+var ES_INDEX_NAME = 'spaceship_project',
+    ES_PORT = 9220,
+    ES_HOST = 'localhost',
+    ES_DOC_TYPE = 'spaceship',
+    LOG_NAME = 'trace';
+
+var ES_DOCS = [
+  {
+    id: '1', 
+    title: ES_DOC_TYPE, 
+    label: 'Fuselage', 
+    produced_date: '2010-09-05', 
+    end_of_work_date: '2030-09-05'
+  },
+  {
+    id: '2', 
+    title: ES_DOC_TYPE, 
+    label: ['Tanks'], 
+    produced_date: ['2010-04-01', '2011-06-09'], 
+    end_of_work_date: ['2023-04-01']
+  },
+  {
+    id: '3', 
+    title: ES_DOC_TYPE, 
+    label: ['Rudder', 'Wing'], 
+    produced_date: ['2012-03-01', '2013-05-01', '2014-08-23'], 
+    end_of_work_date: ['2022-03-01', '2023-05-01', '2024-08-23']
+  },
+  {
+    id: '4', 
+    title: ES_DOC_TYPE, 
+    label: ['Pumps', 'Oxidizer'], 
+    produced_date: ['2015-01-01', '2016-02-01'], 
+    end_of_work_date: ['2022-01-01', '2022-02-01']
+  },
+  {
+    id: '5', 
+    title: ES_DOC_TYPE,
+    label: ['Engine', 'Nozzle', 'Exhaust'], 
+    produced_date: ['2013-01-01', '2014-02-01', '2016-04-07'], 
+    end_of_work_date: ['2023-01-01', '2024-02-01', '2026-04-07']
+  }
+];
+
+function indice_doc_into_es(client, doc, callback) {
+  client.create({
+    index: ES_INDEX_NAME,
+    type: ES_DOC_TYPE,
+    id: doc.id,
+    body: {
+      title: doc.title,
+      label: doc.label,
+      produced_date: doc.produced_date,
+      end_of_work_date: doc.end_of_work_date
+    }
+  }, function (error, response) {
+    if (error) {
+      console.log(format('Error: {0}', error));
+    } else {
+      console.log(response);
+    }
+  });
+
+  if (callback) {
+    callback();
+  }
+}
+
+function search_index (client, query) {
+  console.log('DOCUMENTS:');
+  client.search({
+    index: ES_INDEX_NAME,
+    q: query
+  }, function (error, response) {
+    if (error) {
+      console.log(format('Error: {0}', error));
+    } else {
+      console.log(response);
+    }
+  });
+}
+
+// init ES client API
+var client = new elasticsearch.Client({
+  host: format('{0}:{1}', [ES_HOST, ES_PORT]),
+  log: LOG_NAME
+});
+
+// delete index
+client.indices.delete({
+  index: ES_INDEX_NAME,
+  ignore: [404]
+}).then(function () {
+  console.log(format('The index {0} was deleted!', ES_INDEX_NAME));
+}, function (error) {
+  console.log(format('Error: {0}', error));
+});
+
+// create index
+client.indices.create({
+  index: ES_INDEX_NAME,
+  ignore: [404]
+}).then(function () {
+  console.log(format('The index {0} has been created!', ES_INDEX_NAME));
+
+  var doc;
+  // insert documents
+  for (doc in ES_DOCS) {
+    if (ES_DOCS.hasOwnProperty(doc)) {
+      indice_doc_into_es(client, ES_DOCS[doc]);
+    }
+  }
+
+}, function (error) {
+  console.log(format('Error: {0}', error));
+});
+
+
+

--- a/public/__tests__/kibi_timeline.js
+++ b/public/__tests__/kibi_timeline.js
@@ -132,6 +132,57 @@ describe('KibiTimeline Directive', function () {
     });
   });
 
+  it('should correctly return a timeline if multivalued fields', function () {
+    initTimeline({
+      startField: '@timestamp',
+      endField: '',
+      labelField: 'machine.os'
+    });
+
+    var dates = [ '25-01-2015', '16-12-2016' ];
+    var dateObjs = [ moment(dates[0], 'DD-MM-YYYY'), moment(dates[1], 'DD-MM-YYYY') ];
+    const results = {
+      took: 73,
+      timed_out: false,
+      _shards: {
+        total: 144,
+        successful: 144,
+        failed: 0
+      },
+      hits: {
+        total : 49487,
+        max_score : 1.0,
+        hits: [
+          {
+            _index: 'logstash-2014.09.09',
+            _type: 'apache',
+            _id: '61',
+            _score: 1,
+            _source: {
+              '@timestamp': [ dates[0], dates[1] ],
+              machine: {
+                os: 'linux'
+              }
+            },
+            fields: {
+              '@timestamp': [ dateObjs[0], dateObjs[1] ]
+            }
+          }
+        ]
+      }
+    };
+    searchSource.crankResults(results);
+    $scope.$digest();
+    expect($scope.timeline.itemsData.length).to.be(2);
+    var i = 0;
+    $scope.timeline.itemsData.forEach(data => {
+      sinon.assert.notCalled(searchSource.highlight);
+      expect(data.value).to.be('linux');
+      expect(data.start.valueOf()).to.be(dateObjs[i].valueOf());
+      i++;
+    });
+  });
+
   it('should get the highlighted terms of events if useHighlight is true', function () {
     initTimeline({
       useHighlight: true,

--- a/public/kibi_timeline.js
+++ b/public/kibi_timeline.js
@@ -241,6 +241,13 @@ define(function (require) {
                       (params.useHighlight ? '<p class="tiny-txt">' + timelineHelper.pluckHighlights(hit, highlightTags) +
                       '</p>' : '') + '</div>';
 
+                  let style = 'background-color: ' + groupColor + '; color: #fff;';
+                  if (params.invertFirstLabelInstance &&
+                    !_.includes(uniqueLabels, labelValue.toLowerCase().trim())) {
+                    style = 'background-color: #fff; color: ' + groupColor + ';';
+                    uniqueLabels.push(labelValue.toLowerCase().trim());
+                  }
+
                   const e =  {
                     index: indexId,
                     content: content,
@@ -252,7 +259,7 @@ define(function (require) {
                     },
                     type: 'box',
                     group: $scope.groupsOnSeparateLevels === true ? index : 0,
-                    style: 'background-color: ' + groupColor + '; color: #fff;',
+                    style: style,
                     groupId: groupId
                   };
 

--- a/public/kibi_timeline.js
+++ b/public/kibi_timeline.js
@@ -195,7 +195,7 @@ define(function (require) {
                 startFieldValue = kibiUtils.getValuesAtPath(hit._source, params.startFieldSequence);
               } else {
                 startFieldValue = _.get(hit._source, params.startField);
-                if (startFieldValue !== undefined && startFieldValue !== null) {
+                if (startFieldValue) {
                   startFieldValue = (startFieldValue.constructor !== Array) ? [startFieldValue] : startFieldValue;
                 }
               }
@@ -207,7 +207,7 @@ define(function (require) {
                   endFieldValue = kibiUtils.getValuesAtPath(hit._source, params.endFieldSequence);
                 } else {
                   endFieldValue = _.get(hit._source, params.endField);
-                  if (endFieldValue !== undefined && endFieldValue !== null) {
+                  if (endFieldValue) {
                     endFieldValue = (endFieldValue.constructor !== Array) ? [endFieldValue] : endFieldValue;
                   }
                 }

--- a/public/kibi_timeline.js
+++ b/public/kibi_timeline.js
@@ -187,7 +187,6 @@ define(function (require) {
             let endRawFieldValue;
 
             _.each(searchResp.hits.hits, function (hit) {
-              $scope.visOptions.notifyDataErrors = false;
               let labelValue = timelineHelper.pluckLabel(hit, params, notify);
               labelValue = (labelValue.constructor === Array) ? labelValue.join(', ') : labelValue;
 
@@ -214,15 +213,13 @@ define(function (require) {
                 endRawFieldValue = hit.fields[params.endField];
 
                 if (endFieldValue.length !== startFieldValue.length) {
-                  $scope.visOptions.notifyDataErrors = true;
+                  if ($scope.visOptions.notifyDataErrors) {
+                    notify.warning('Check your data - the number of values in the field \'' + params.endField + '\' ' +
+                                   'must be equal to the number of values in the field \'' + params.startField +
+                                   '\': document ID=' + hit._id);
+                  }
+                  return; // break
                 }
-              }
-
-              if ($scope.visOptions.notifyDataErrors) {
-                notify.warning('Check your data - the number of values in the \'' + params.endField + '\' ' +
-                'must be equal to the number of values in the \'' + params.startField +
-                '\'. Document id ' + hit._id);
-                return;
               }
 
               if (startFieldValue && (!_.isArray(startFieldValue) || startFieldValue.length)) {

--- a/public/kibi_timeline.js
+++ b/public/kibi_timeline.js
@@ -177,7 +177,6 @@ define(function (require) {
           });
         }
 
-
         searchSource.onResults().then(function onResults(searchResp) {
           let events = [];
 
@@ -188,7 +187,6 @@ define(function (require) {
             let endRawFieldValue;
 
             _.each(searchResp.hits.hits, function (hit) {
-
               let labelValue = timelineHelper.pluckLabel(hit, params, notify);
               if (params.startFieldSequence) { // in kibi, we have the path property of a field
                 startFieldValue = kibiUtils.getValuesAtPath(hit._source, params.startFieldSequence);

--- a/public/kibi_timeline.js
+++ b/public/kibi_timeline.js
@@ -189,10 +189,15 @@ define(function (require) {
             _.each(searchResp.hits.hits, function (hit) {
               $scope.visOptions.notifyDataErrors = false;
               let labelValue = timelineHelper.pluckLabel(hit, params, notify);
+              labelValue = (labelValue.constructor === Array) ? labelValue.join(', ') : labelValue;
+
               if (params.startFieldSequence) { // in kibi, we have the path property of a field
                 startFieldValue = kibiUtils.getValuesAtPath(hit._source, params.startFieldSequence);
               } else {
                 startFieldValue = _.get(hit._source, params.startField);
+                if (startFieldValue !== undefined && startFieldValue !== null) {
+                  startFieldValue = (startFieldValue.constructor !== Array) ? [startFieldValue] : startFieldValue;
+                }
               }
               startRawFieldValue = hit.fields[params.startField];
 
@@ -202,6 +207,9 @@ define(function (require) {
                   endFieldValue = kibiUtils.getValuesAtPath(hit._source, params.endFieldSequence);
                 } else {
                   endFieldValue = _.get(hit._source, params.endField);
+                  if (endFieldValue !== undefined && endFieldValue !== null) {
+                    endFieldValue = (endFieldValue.constructor !== Array) ? [endFieldValue] : endFieldValue;
+                  }
                 }
                 endRawFieldValue = hit.fields[params.endField];
 
@@ -220,7 +228,7 @@ define(function (require) {
               if (startFieldValue && (!_.isArray(startFieldValue) || startFieldValue.length)) {
                 let indexId = searchSource.get('index').id;
 
-                startFieldValue.forEach(function (value, i) {
+                _.each(startFieldValue, function (value, i) {
                   let startValue = value;
                   let startRawValue = startRawFieldValue[i];
 
@@ -228,14 +236,14 @@ define(function (require) {
                       '<div title="index: ' + indexId +
                       ', startField: ' + params.startField +
                       (params.endField ? ', endField: ' + params.endField : '') +
-                      '">' + labelValue.join(', ') +
+                      '">' + labelValue +
                       (params.useHighlight ? '<p class="tiny-txt">' + timelineHelper.pluckHighlights(hit, highlightTags) +
                       '</p>' : '') + '</div>';
 
                   let e =  {
                     index: indexId,
                     content: content,
-                    value: labelValue[i],
+                    value: labelValue,
                     start: new Date(startRawValue),
                     startField: {
                       name: params.startField,

--- a/public/kibi_timeline.js
+++ b/public/kibi_timeline.js
@@ -1,20 +1,20 @@
 define(function (require) {
   require('ui/highlight/highlight_tags');
-  let _ = require('lodash');
-  let vis = require('vis');
-  let buildRangeFilter = require('ui/filter_manager/lib/range');
+  const _ = require('lodash');
+  const vis = require('vis');
+  const buildRangeFilter = require('ui/filter_manager/lib/range');
 
   require('ui/modules').get('kibana').directive('kibiTimeline',
   function (Private, createNotifier, courier, indexPatterns, config, highlightTags, timefilter) {
     const kibiUtils = require('kibiutils');
     const NUM_FRAGS_CONFIG = 'kibi:timeline:highlight:number_of_fragments';
     const DEFAULT_NUM_FRAGS = 25;
-    let requestQueue = Private(require('./lib/courier/_request_queue_wrapped'));
-    let timelineHelper = Private(require('./lib/helpers/timeline_helper'));
+    const requestQueue = Private(require('./lib/courier/_request_queue_wrapped'));
+    const timelineHelper = Private(require('./lib/helpers/timeline_helper'));
 
-    let queryFilter = Private(require('ui/filter_bar/query_filter'));
+    const queryFilter = Private(require('ui/filter_bar/query_filter'));
 
-    let notify = createNotifier({
+    const notify = createNotifier({
       location: 'Kibi Timeline'
     });
 
@@ -39,7 +39,7 @@ define(function (require) {
           if ($scope.visOptions.selectValue === 'date') {
             if (selected.start && !selected.end) {
               // single point - do query match query filter
-              let q1 = {
+              const q1 = {
                 query: {
                   match: {}
                 },
@@ -56,19 +56,19 @@ define(function (require) {
             } else if (selected.start && selected.end) {
               // range - do 2 range filters
               indexPatterns.get(selected.index).then(function (i) {
-                let startF = _.find(i.fields, function (f) {
+                const startF = _.find(i.fields, function (f) {
                   return f.name === selected.startField.name;
                 });
-                let endF = _.find(i.fields, function (f) {
+                const endF = _.find(i.fields, function (f) {
                   return f.name === selected.endField.name;
                 });
 
-                let rangeFilter1 = buildRangeFilter(startF, {
+                const rangeFilter1 = buildRangeFilter(startF, {
                   gte: selected.startField.value
                 }, i);
                 rangeFilter1.meta.alias = selected.startField.name + ' >= ' + selected.start;
 
-                let rangeFilter2 = buildRangeFilter(endF, {
+                const rangeFilter2 = buildRangeFilter(endF, {
                   lte: selected.endField.value
                 }, i);
                 rangeFilter2.meta.alias = selected.endField.name + ' <= ' + selected.end;
@@ -83,7 +83,7 @@ define(function (require) {
                 searchField = $scope.visOptions.groups[i].params.labelField;
               }
             }
-            let q2 = {
+            const q2 = {
               query: {
                 match: {}
               },
@@ -100,7 +100,7 @@ define(function (require) {
         }
       };
 
-      let initTimeline = function () {
+      const initTimeline = function () {
         if (!timeline) {
           // create a new one
           $scope.timeline = timeline = new vis.Timeline($element[0]);
@@ -124,10 +124,10 @@ define(function (require) {
         }
       };
 
-      let groupEvents = [];
+      const groupEvents = [];
 
-      let updateTimeline = function (groupIndex, events) {
-        let existingGroupIds = _.map($scope.visOptions.groups, function (g) {
+      const updateTimeline = function (groupIndex, events) {
+        const existingGroupIds = _.map($scope.visOptions.groups, function (g) {
           return g.id;
         });
 
@@ -135,7 +135,7 @@ define(function (require) {
 
         // make sure all events have correct group index
         // add only events from groups which still exists
-        let points = [];
+        const points = [];
         _.each(groupEvents, function (events, index) {
           _.each(events, function (e) {
             e.group = $scope.visOptions.groupsOnSeparateLevels === true ? index : 0;
@@ -150,7 +150,7 @@ define(function (require) {
         timeline.fit();
       };
 
-      let initSingleGroup = function (group, index) {
+      const initSingleGroup = function (group, index) {
         const searchSource = group.searchSource;
         const params = group.params;
         const groupId = group.id;
@@ -181,7 +181,7 @@ define(function (require) {
         }
 
         searchSource.onResults().then(function onResults(searchResp) {
-          let events = [];
+          const events = [];
 
           if (params.startField) {
             let startFieldValue;
@@ -227,13 +227,13 @@ define(function (require) {
               }
 
               if (startFieldValue && (!_.isArray(startFieldValue) || startFieldValue.length)) {
-                let indexId = searchSource.get('index').id;
+                const indexId = searchSource.get('index').id;
 
                 _.each(startFieldValue, function (value, i) {
-                  let startValue = value;
-                  let startRawValue = startRawFieldValue[i];
+                  const startValue = value;
+                  const startRawValue = startRawFieldValue[i];
 
-                  var content =
+                  const content =
                       '<div title="index: ' + indexId +
                       ', startField: ' + params.startField +
                       (params.endField ? ', endField: ' + params.endField : '') +
@@ -241,7 +241,7 @@ define(function (require) {
                       (params.useHighlight ? '<p class="tiny-txt">' + timelineHelper.pluckHighlights(hit, highlightTags) +
                       '</p>' : '') + '</div>';
 
-                  let e =  {
+                  const e =  {
                     index: indexId,
                     content: content,
                     value: labelValue,
@@ -262,8 +262,8 @@ define(function (require) {
                       // force the event to be of type point
                       e.type = 'point';
                     } else {
-                      let endValue = endFieldValue[i];
-                      let endRawValue = endRawFieldValue[i];
+                      const endValue = endFieldValue[i];
+                      const endRawValue = endRawFieldValue[i];
                       if (startValue === endValue) {
                         // also force it to be a point
                         e.type = 'point';

--- a/public/kibi_timeline.js
+++ b/public/kibi_timeline.js
@@ -211,9 +211,8 @@ define(function (require) {
               }
 
               if ($scope.visOptions.notifyDataErrors) {
-                notify.warning('Check your data - the number of values in the \'Event end date\' - ' +
-                '\'' + params.endField + '\' ' +
-                'must be equal to the number of values in the \'Event start date\' - \'' + params.startField +
+                notify.warning('Check your data - the number of values in the \'' + params.endField + '\' ' +
+                'must be equal to the number of values in the \'' + params.startField +
                 '\'. Document id ' + hit._id);
                 return;
               }
@@ -225,24 +224,13 @@ define(function (require) {
                   let startValue = value;
                   let startRawValue = startRawFieldValue[i];
 
-                  var content;
-                  if (labelValue.length === startFieldValue.length) {
-                    content =
-                      '<div title="index: ' + indexId +
-                      ', startField: ' + params.startField +
-                      (params.endField ? ', endField: ' + params.endField : '') +
-                      '">' + labelValue[i] +
-                      (params.useHighlight ? '<p class="tiny-txt">' + timelineHelper.pluckHighlights(hit, highlightTags) + '</p>' : '') +
-                      '</div>';
-                  } else {
-                    content =
+                  var content =
                       '<div title="index: ' + indexId +
                       ', startField: ' + params.startField +
                       (params.endField ? ', endField: ' + params.endField : '') +
                       '">' + labelValue.join(', ') +
-                      (params.useHighlight ? '<p class="tiny-txt">' + timelineHelper.pluckHighlights(hit, highlightTags) + '</p>' : '') +
-                      '</div>';
-                  }
+                      (params.useHighlight ? '<p class="tiny-txt">' + timelineHelper.pluckHighlights(hit, highlightTags) +
+                      '</p>' : '') + '</div>';
 
                   let e =  {
                     index: indexId,

--- a/public/kibi_timeline.js
+++ b/public/kibi_timeline.js
@@ -177,18 +177,18 @@ define(function (require) {
           });
         }
 
+
         searchSource.onResults().then(function onResults(searchResp) {
           let events = [];
 
           if (params.startField) {
-            let detectedMultivaluedStart;
-            let detectedMultivaluedEnd;
             let startFieldValue;
             let startRawFieldValue;
             let endFieldValue;
             let endRawFieldValue;
 
             _.each(searchResp.hits.hits, function (hit) {
+
               let labelValue = timelineHelper.pluckLabel(hit, params, notify);
               if (params.startFieldSequence) { // in kibi, we have the path property of a field
                 startFieldValue = kibiUtils.getValuesAtPath(hit._source, params.startFieldSequence);
@@ -198,68 +198,87 @@ define(function (require) {
               startRawFieldValue = hit.fields[params.startField];
 
               let endFieldValue = null;
+              if (params.endField) {
+                if (params.endFieldSequence) { // in kibi, we have the path property of a field
+                  endFieldValue = kibiUtils.getValuesAtPath(hit._source, params.endFieldSequence);
+                } else {
+                  endFieldValue = _.get(hit._source, params.endField);
+                }
+                endRawFieldValue = hit.fields[params.endField];
+
+                if (endFieldValue.length !== startFieldValue.length) {
+                  notify.warning('Check your data - the number of values of the \'Event end date\'' +
+                  ' must be equal to the number of values of the \'Event start date\'');
+                  return;
+                }
+              }
 
               if (startFieldValue && (!_.isArray(startFieldValue) || startFieldValue.length)) {
-                if (timelineHelper.isMultivalued(startFieldValue)) {
-                  detectedMultivaluedStart = true;
-                }
                 let indexId = searchSource.get('index').id;
-                let startValue = timelineHelper.pickFirstIfMultivalued(startFieldValue);
-                let startRawValue = timelineHelper.pickFirstIfMultivalued(startRawFieldValue);
-                let content =
-                  '<div title="index: ' + indexId +
-                  ', startField: ' + params.startField +
-                  (params.endField ? ', endField: ' + params.endField : '') +
-                  '">' + labelValue +
-                  (params.useHighlight ? '<p class="tiny-txt">' + timelineHelper.pluckHighlights(hit, highlightTags) + '</p>' : '') +
-                  '</div>';
 
-                let e =  {
-                  index: indexId,
-                  content: content,
-                  value: labelValue,
-                  start: new Date(startRawValue),
-                  startField: {
-                    name: params.startField,
-                    value: startValue
-                  },
-                  type: 'box',
-                  group: $scope.visOptions.groupsOnSeparateLevels === true ? index : 0,
-                  style: 'background-color: ' + groupColor + '; color: #fff;',
-                  groupId: groupId
-                };
+                startFieldValue.forEach(function (value, i) {
+                  let startValue = value;
+                  let startRawValue = startRawFieldValue[i];
 
-                if (params.endField) {
-                  if (params.endFieldSequence) { // in kibi, we have the path property of a field
-                    endFieldValue = kibiUtils.getValuesAtPath(hit._source, params.endFieldSequence);
+                  var content;
+                  if (labelValue.length === startFieldValue.length) {
+                    content =
+                      '<div title="index: ' + indexId +
+                      ', startField: ' + params.startField +
+                      (params.endField ? ', endField: ' + params.endField : '') +
+                      '">' + labelValue[i] +
+                      (params.useHighlight ? '<p class="tiny-txt">' + timelineHelper.pluckHighlights(hit, highlightTags) + '</p>' : '') +
+                      '</div>';
                   } else {
-                    endFieldValue = _.get(hit._source, params.endField);
+                    content =
+                      '<div title="index: ' + indexId +
+                      ', startField: ' + params.startField +
+                      (params.endField ? ', endField: ' + params.endField : '') +
+                      '">' + labelValue.join() +
+                      (params.useHighlight ? '<p class="tiny-txt">' + timelineHelper.pluckHighlights(hit, highlightTags) + '</p>' : '') +
+                      '</div>';
                   }
-                  endRawFieldValue = hit.fields[params.endField];
-                  if (timelineHelper.isMultivalued(endFieldValue)) {
-                    detectedMultivaluedEnd = true;
-                  }
-                  if (!endFieldValue) {
-                    // here the end field value missing but expected
-                    // force the event to be of type point
-                    e.type = 'point';
-                  } else {
-                    let endValue = timelineHelper.pickFirstIfMultivalued(endFieldValue);
-                    let endRawValue = timelineHelper.pickFirstIfMultivalued(endRawFieldValue);
-                    if (startValue === endValue) {
-                      // also force it to be a point
+
+                  let e =  {
+                    index: indexId,
+                    content: content,
+                    value: labelValue[i],
+                    start: new Date(startRawValue),
+                    startField: {
+                      name: params.startField,
+                      value: startValue
+                    },
+                    type: 'box',
+                    group: $scope.groupsOnSeparateLevels === true ? index : 0,
+                    style: 'background-color: ' + groupColor + '; color: #fff;',
+                    groupId: groupId
+                  };
+
+                  if (params.endField) {
+                    if (!endFieldValue) {
+                      // here the end field value missing but expected
+                      // force the event to be of type point
                       e.type = 'point';
                     } else {
-                      e.type = 'range';
-                      e.end =  new Date(endRawValue);
-                      e.endField = {
-                        name: params.endField,
-                        value: endValue
-                      };
+                      let endValue = endFieldValue[i];
+                      let endRawValue = endRawFieldValue[i];
+                      if (startValue === endValue) {
+                        // also force it to be a point
+                        e.type = 'point';
+                      } else {
+                        e.type = 'range';
+                        e.end =  new Date(endRawValue);
+                        e.endField = {
+                          name: params.endField,
+                          value: endValue
+                        };
+                      }
                     }
                   }
-                }
-                events.push(e);
+
+                  events.push(e);
+
+                });
               } else {
                 if ($scope.visOptions.notifyDataErrors) {
                   notify.warning('Check your data - null start date not allowed.' +
@@ -268,14 +287,6 @@ define(function (require) {
                 return;
               }
             });
-
-            if (detectedMultivaluedStart) {
-              notify.warning('Start Date field [' + params.startField + '] is multivalued - the first date will be used.');
-            }
-            if (detectedMultivaluedEnd) {
-              notify.warning('End Date field [' + params.endField + '] is multivalued - the first date will be used.');
-            }
-
           }
 
           updateTimeline(index, events);

--- a/public/kibi_timeline.js
+++ b/public/kibi_timeline.js
@@ -192,14 +192,16 @@ define(function (require) {
 
             _.each(searchResp.hits.hits, function (hit) {
               let labelValue = timelineHelper.pluckLabel(hit, params, notify);
-              labelValue = (labelValue.constructor === Array) ? labelValue.join(', ') : labelValue;
+              if (labelValue.constructor === Array) {
+                labelValue = labelValue.join(', ');
+              }
 
               if (params.startFieldSequence) { // in kibi, we have the path property of a field
                 startFieldValue = kibiUtils.getValuesAtPath(hit._source, params.startFieldSequence);
               } else {
                 startFieldValue = _.get(hit._source, params.startField);
-                if (startFieldValue) {
-                  startFieldValue = (startFieldValue.constructor !== Array) ? [startFieldValue] : startFieldValue;
+                if (startFieldValue && startFieldValue.constructor !== Array) {
+                  startFieldValue =  [ startFieldValue ];
                 }
               }
               startRawFieldValue = hit.fields[params.startField];

--- a/public/kibi_timeline.js
+++ b/public/kibi_timeline.js
@@ -207,8 +207,8 @@ define(function (require) {
                 endRawFieldValue = hit.fields[params.endField];
 
                 if (endFieldValue.length !== startFieldValue.length) {
-                  notify.warning('Check your data - the number of values of the \'Event end date\'' +
-                  ' must be equal to the number of values of the \'Event start date\'');
+                  notify.warning('Check your data - the number of values in the \'Event end date\'' +
+                  ' must be equal to the number of values in the \'Event start date\'');
                   return;
                 }
               }

--- a/public/kibi_timeline.js
+++ b/public/kibi_timeline.js
@@ -187,6 +187,7 @@ define(function (require) {
             let endRawFieldValue;
 
             _.each(searchResp.hits.hits, function (hit) {
+              $scope.visOptions.notifyDataErrors = false;
               let labelValue = timelineHelper.pluckLabel(hit, params, notify);
               if (params.startFieldSequence) { // in kibi, we have the path property of a field
                 startFieldValue = kibiUtils.getValuesAtPath(hit._source, params.startFieldSequence);
@@ -205,10 +206,16 @@ define(function (require) {
                 endRawFieldValue = hit.fields[params.endField];
 
                 if (endFieldValue.length !== startFieldValue.length) {
-                  notify.warning('Check your data - the number of values in the \'Event end date\'' +
-                  ' must be equal to the number of values in the \'Event start date\'');
-                  return;
+                  $scope.visOptions.notifyDataErrors = true;
                 }
+              }
+
+              if ($scope.visOptions.notifyDataErrors) {
+                notify.warning('Check your data - the number of values in the \'Event end date\' - ' +
+                '\'' + params.endField + '\' ' +
+                'must be equal to the number of values in the \'Event start date\' - \'' + params.startField +
+                '\'. Document id ' + hit._id);
+                return;
               }
 
               if (startFieldValue && (!_.isArray(startFieldValue) || startFieldValue.length)) {

--- a/public/kibi_timeline.js
+++ b/public/kibi_timeline.js
@@ -234,7 +234,7 @@ define(function (require) {
                       '<div title="index: ' + indexId +
                       ', startField: ' + params.startField +
                       (params.endField ? ', endField: ' + params.endField : '') +
-                      '">' + labelValue.join() +
+                      '">' + labelValue.join(', ') +
                       (params.useHighlight ? '<p class="tiny-txt">' + timelineHelper.pluckHighlights(hit, highlightTags) + '</p>' : '') +
                       '</div>';
                   }

--- a/public/lib/helpers/__tests__/timeline_helper.js
+++ b/public/lib/helpers/__tests__/timeline_helper.js
@@ -23,20 +23,6 @@ describe('Kibi Timeline', function () {
       });
     });
 
-    describe('isMultivalued', function () {
-      it('should return true if value is an array and mutlivalued', function () {
-        expect(timelineHelper.isMultivalued([ 1, 2 ])).to.be(true);
-      });
-
-      it('should return false if value is an array but has only one value', function () {
-        expect(timelineHelper.isMultivalued([ 1 ])).to.be(false);
-      });
-
-      it('should return false if value is not an array', function () {
-        expect(timelineHelper.isMultivalued(1)).to.be(false);
-      });
-    });
-
     describe('pluckLabel', function () {
       let notify;
 

--- a/public/lib/helpers/__tests__/timeline_helper.js
+++ b/public/lib/helpers/__tests__/timeline_helper.js
@@ -53,7 +53,7 @@ describe('Kibi Timeline', function () {
           labelFieldSequence: [ 'aaa' ]
         };
 
-        expect(timelineHelper.pluckLabel(hit, params, notify)).to.be('bbb');
+        expect(timelineHelper.pluckLabel(hit, params, notify)).to.eql(['bbb']);
         sinon.assert.notCalled(notify.warning);
       });
 
@@ -70,21 +70,6 @@ describe('Kibi Timeline', function () {
 
         expect(timelineHelper.pluckLabel(hit, params, notify)).to.be('N/A');
         sinon.assert.notCalled(notify.warning);
-      });
-
-      it('should display a warning if the label field is multivalued', function () {
-        const hit = {
-          _source: {
-            aaa: [ 'bbb', 'ccc' ]
-          }
-        };
-        const params = {
-          labelField: 'aaa',
-          labelFieldSequence: [ 'aaa' ]
-        };
-
-        expect(timelineHelper.pluckLabel(hit, params, notify)).to.be('bbb');
-        sinon.assert.called(notify.warning);
       });
     });
 

--- a/public/lib/helpers/timeline_helper.js
+++ b/public/lib/helpers/timeline_helper.js
@@ -7,10 +7,6 @@ define(function (require) {
     function TimelineHelper() {
     }
 
-    TimelineHelper.prototype.isMultivalued = function (value) {
-      return value instanceof Array && value.length > 1;
-    };
-
     TimelineHelper.prototype.changeTimezone  = function (timezone) {
       if (timezone !== 'Browser') {
         return moment().tz(timezone).format('Z');

--- a/public/lib/helpers/timeline_helper.js
+++ b/public/lib/helpers/timeline_helper.js
@@ -11,18 +11,6 @@ define(function (require) {
       return value instanceof Array && value.length > 1;
     };
 
-    TimelineHelper.prototype.pickFirstIfMultivalued  = function (value, defaultValue) {
-      if (!value) {
-        return defaultValue || '';
-      } else {
-        if (value instanceof Array && value.length > 0) {
-          return value[0];
-        } else {
-          return value;
-        }
-      }
-    };
-
     TimelineHelper.prototype.changeTimezone  = function (timezone) {
       if (timezone !== 'Browser') {
         return moment().tz(timezone).format('Z');

--- a/public/lib/helpers/timeline_helper.js
+++ b/public/lib/helpers/timeline_helper.js
@@ -49,10 +49,7 @@ define(function (require) {
         field = _.get(hit._source, params.labelField);
       }
       if (field && (!_.isArray(field) || field.length)) {
-        if (this.isMultivalued(field)) {
-          notify.warning('Label field [' + params.labelField + '] is multivalued - the first value will be used.');
-        }
-        label = this.pickFirstIfMultivalued(field, 'N/A');
+        return field;
       }
       return label;
     };


### PR DESCRIPTION
A new PR to resolve conflicts in https://github.com/sirensolutions/kibi_timeline_vis/pull/91

There is one error in test:
```
should sort on the start field if invertFirstLabelInstance ‣
Error: expected 'background-color: #ff0000; color: #fff;' to match /background-color: #fff/
    at Assertion.assert (http://localhost:5610/bundles/tests.bundle.js:312663:14)
    at Assertion.match (http://localhost:5610/bundles/tests.bundle.js:312895:11)
    at http://localhost:5610/bundles/tests.bundle.js:373426:34
    at o.forEach (http://localhost:5610/bundles/tests.bundle.js:260837:25301)
    at Context.<anonymous> (http://localhost:5610/bundles/tests.bundle.js:373419:32)
```