### PR TITLE
Add multifields support

### DIFF
--- a/public/__tests__/kibi_timeline.js
+++ b/public/__tests__/kibi_timeline.js
@@ -381,23 +381,23 @@ describe('KibiTimeline Directive', function () {
         case 0:
           expect(data.value).to.be('linux');
           expect(data.start.valueOf()).to.be(date1Obj.valueOf());
-          // color is inverted
+          // emphasized, border style is solid
           expect(data.style).to.match(/color: #ff0000/);
-          expect(data.style).to.match(/background-color: #fff/);
+          expect(data.style).to.match(/border-style: solid/);
           break;
         case 1:
           expect(data.value).to.be('mac');
           expect(data.start.valueOf()).to.be(date2Obj.valueOf());
-          // color is inverted
+          // emphasized, border style is solid
           expect(data.style).to.match(/color: #ff0000/);
-          expect(data.style).to.match(/background-color: #fff/);
+          expect(data.style).to.match(/border-style: solid/);
           break;
         case 2:
           expect(data.value).to.be('linux');
           expect(data.start.valueOf()).to.be(date3Obj.valueOf());
-          // color is normal
-          expect(data.style).to.match(/color: #fff/);
-          expect(data.style).to.match(/background-color: #ff0000/);
+          // border style is none
+          expect(data.style).to.match(/color: #ff0000/);
+          expect(data.style).to.match(/border-style: none/);
           break;
         default:
           expect().fail(`Should not have the case itemIndex=${itemIndex}`);

--- a/public/__tests__/kibi_timeline_vis_controller.js
+++ b/public/__tests__/kibi_timeline_vis_controller.js
@@ -333,18 +333,18 @@ describe('Kibi Timeline', function () {
         expect($scope.visOptions.groups).to.have.length(2);
 
         const expectedA = {
-          labelFieldSequence: [ 'd.o', 't.labelFieldA' ],
-          startFieldSequence: [ 'd.o', 't.startFieldA' ],
-          endFieldSequence: [ 'd.o', 't.endFieldA' ],
+          labelFieldSequence: [ 'd.o.t.labelFieldA' ],
+          startFieldSequence: [ 'd.o.t.startFieldA' ],
+          endFieldSequence: [ 'd.o.t.endFieldA' ],
           searchSourceId: '_kibi_timetable_ids_source_flagidAsavedSearchIdA'
         };
         _.assign(expectedA, groups[0]);
         assertGroup($scope.visOptions.groups[0], expectedA);
 
         const expectedB = {
-          labelFieldSequence: [ 'd.o', 't.labelFieldB' ],
-          startFieldSequence: [ 'd.o', 't.startFieldB' ],
-          endFieldSequence: [ 'd.o', 't.endFieldB' ],
+          labelFieldSequence: [ 'd.o.t.labelFieldB' ],
+          startFieldSequence: [ 'd.o.t.startFieldB' ],
+          endFieldSequence: [ 'd.o.t.endFieldB' ],
           searchSourceId: '_kibi_timetable_ids_source_flagidBsavedSearchIdB'
         };
         _.assign(expectedB, groups[1]);

--- a/public/kibi_timeline.js
+++ b/public/kibi_timeline.js
@@ -205,6 +205,13 @@ define(function (require) {
                 }
               }
               startRawFieldValue = hit.fields[params.startField];
+              // multifield case
+              // if there is date in fields but not in source, get from fields
+              if (startRawFieldValue.length > 0 && startFieldValue.length === 0) {
+                const aDate = new Date(startRawFieldValue[0]);
+                startFieldValue.push(`${aDate.getFullYear()}-${aDate.getMonth() + 1}-${aDate.getDate()}`);
+              }
+
 
               let endFieldValue = null;
               if (params.endField) {
@@ -217,6 +224,13 @@ define(function (require) {
                   }
                 }
                 endRawFieldValue = hit.fields[params.endField];
+                // multifield case
+                // if there is date in fields but not in source, get from fields
+                if (endRawFieldValue.length > 0 && endFieldValue.length === 0) {
+                  const aDate = new Date(endRawFieldValue[0]);
+                  endFieldValue.push(`${aDate.getFullYear()}-${aDate.getMonth() + 1}-${aDate.getDate()}`);
+                }
+
 
                 if (endFieldValue.length !== startFieldValue.length) {
                   if ($scope.visOptions.notifyDataErrors) {

--- a/public/kibi_timeline.js
+++ b/public/kibi_timeline.js
@@ -207,7 +207,7 @@ define(function (require) {
               startRawFieldValue = hit.fields[params.startField];
               // multifield case
               // if there is date in fields but not in source, get from fields
-              if (startRawFieldValue.length > 0 && startFieldValue.length === 0) {
+              if (startRawFieldValue && startRawFieldValue.length > 0 && startFieldValue.length === 0) {
                 const aDate = new Date(startRawFieldValue[0]);
                 startFieldValue.push(`${aDate.getFullYear()}-${aDate.getMonth() + 1}-${aDate.getDate()}`);
               }

--- a/public/kibi_timeline_vis.less
+++ b/public/kibi_timeline_vis.less
@@ -62,3 +62,20 @@
 .vis-panel .vis-shadow {
   box-shadow: none!important; /* disable the shadow */
 }
+
+.kibi-tl-dot-item {
+  position: relative;
+  padding: 0;
+  border-width: 4px;
+  border-style: solid;
+  border-radius: 4px;
+  float: left;
+  margin-top: 6px;
+  margin-right: 4px;
+  border-color: red;
+}
+
+.kibi-tl-label-item {
+  margin-left: 15px;
+}
+

--- a/public/kibi_timeline_vis_controller.js
+++ b/public/kibi_timeline_vis_controller.js
@@ -58,6 +58,10 @@ define(function (require) {
           $scope.visOptions.groups = [];
           _.each(savedSearchesRes, function ({ savedSearch, groups }, i) {
             for (const group of groups) {
+              // get parent field if multifield
+              // because doc_values feature is not applied to string fields
+              group.labelField = group.labelField.length > 0 ? group.labelField.split('.')[0] : group.labelField;
+
               const _id = `_kibi_timetable_ids_source_flag${group.id}${savedSearch.id}`; // used only by kibi
               requestQueue.markAllRequestsWithSourceIdAsInactive(_id); // used only by kibi
 

--- a/public/kibi_timeline_vis_controller.js
+++ b/public/kibi_timeline_vis_controller.js
@@ -82,8 +82,10 @@ define(function (require) {
                   //kibi params
                   labelFieldSequence: timelineHelper.isMultifield(group.labelField) ? [group.labelField]
                     : fields[i].byName[group.labelField].path,
-                  startFieldSequence: fields[i].byName[group.startField].path,
-                  endFieldSequence: group.endField && fields[i].byName[group.endField].path || [],
+                  startFieldSequence: timelineHelper.isMultifield(group.startField) ? [group.startField]
+                    : fields[i].byName[group.startField].path,
+                  endFieldSequence: group.endField && (timelineHelper.isMultifield(group.endField)
+                    ? [group.endField] : fields[i].byName[group.endField].path) || [],
                   //kibana params
                   labelField: group.labelField,
                   startField: group.startField,

--- a/public/kibi_timeline_vis_controller.js
+++ b/public/kibi_timeline_vis_controller.js
@@ -150,34 +150,34 @@ define(function (require) {
         }
       });
 
+      // It is necessary to listen to those two events because the timeline visualization does not have
+      // requiresSearch set to true since it needs more that one search.
+
+      // on kibi, the editors.js file is updated to support requiresMultiSearch so that a courier.fetch call is executed
+      const chrome = require('ui/chrome');
+      const isKibi = chrome.getAppTitle() === 'Kibi';
+
+      // update the searchSource when filters update
+      $scope.$listen(queryFilter, 'update', function () {
+        _.each($scope.visOptions.groups, group => group.searchSource.set('filter', queryFilter.getFilters()));
+        if (!isKibi) {
+          courier.fetch();
+        }
+      });
+      // fetch when the time changes
+      $scope.$listen(timefilter, 'fetch', () => {
+        _.each($scope.visOptions.groups, group => {
+          group.searchSource.fetchQueued();
+        });
+        if (!isKibi) {
+          courier.fetch();
+        }
+      });
+
       if (configMode) {
         const removeVisStateChangedHandler = $rootScope.$on('kibi:vis:state-changed', function () {
           $scope.initOptions();
           $scope.initSearchSources($scope.savedVis);
-        });
-
-        // It is necessary to listen to those two events because the timeline visualization does not have
-        // requiresSearch set to true since it needs more that one search.
-
-        // on kibi, the editors.js file is updated to support requiresMultiSearch so that a courier.fetch call is executed
-        const chrome = require('ui/chrome');
-        const isKibi = chrome.getAppTitle() === 'Kibi';
-
-        // update the searchSource when filters update
-        $scope.$listen(queryFilter, 'update', function () {
-          _.each($scope.visOptions.groups, group => group.searchSource.set('filter', queryFilter.getFilters()));
-          if (!isKibi) {
-            courier.fetch();
-          }
-        });
-        // fetch when the time changes
-        $scope.$listen(timefilter, 'fetch', () => {
-          _.each($scope.visOptions.groups, group => {
-            group.searchSource.fetchQueued();
-          });
-          if (!isKibi) {
-            courier.fetch();
-          }
         });
 
         $scope.$on('$destroy', function () {

--- a/public/kibi_timeline_vis_controller.js
+++ b/public/kibi_timeline_vis_controller.js
@@ -184,6 +184,5 @@ define(function (require) {
           removeVisStateChangedHandler();
         });
       }
-
     });
 });

--- a/public/lib/helpers/timeline_helper.js
+++ b/public/lib/helpers/timeline_helper.js
@@ -7,6 +7,31 @@ define(function (require) {
     function TimelineHelper() {
     }
 
+    TimelineHelper.prototype.noEndOrEqual = function (startValue, endValue) {
+      return !endValue || startValue === endValue ? true : false;
+    };
+
+    TimelineHelper.prototype.createItemTemplate = function (itemDict) {
+      let endfield = '';
+      let dot = '';
+      let hilit = '';
+      let label = itemDict.labelValue;
+
+      if (itemDict.endField) {
+        endfield = `, endField: ${itemDict.endField}`;
+      }
+      if (this.noEndOrEqual(itemDict.startValue, itemDict.endValue)) {
+        dot = `<div class="kibi-tl-dot-item" style="border-color:${itemDict.groupColor}"></div>`;
+        label = `<div class="kibi-tl-label-item">${itemDict.labelValue}</div>`;
+      }
+      if (itemDict.useHighlight) {
+        hilit = `<p class="tiny-txt">${itemDict.highlight}</p>`;
+      }
+
+      return `<div title="index: ${itemDict.indexId}, startField: ${itemDict.startField}${endfield}">` +
+          `${dot}${label}${hilit}</div>`;
+    };
+
     TimelineHelper.prototype.changeTimezone  = function (timezone) {
       if (timezone !== 'Browser') {
         return moment().tz(timezone).format('Z');

--- a/public/lib/helpers/timeline_helper.js
+++ b/public/lib/helpers/timeline_helper.js
@@ -30,6 +30,7 @@ define(function (require) {
 
       return `<div title="index: ${itemDict.indexId}, startField: ${itemDict.startField}${endfield}">` +
           `${dot}${label}${hilit}</div>`;
+    };
 
     TimelineHelper.prototype.isMultifield  = function (str) {
       if (str.indexOf('.') > -1) {

--- a/public/lib/helpers/timeline_helper.js
+++ b/public/lib/helpers/timeline_helper.js
@@ -30,6 +30,13 @@ define(function (require) {
 
       return `<div title="index: ${itemDict.indexId}, startField: ${itemDict.startField}${endfield}">` +
           `${dot}${label}${hilit}</div>`;
+
+    TimelineHelper.prototype.isMultifield  = function (str) {
+      if (str.indexOf('.') > -1) {
+        return true;
+      } else {
+        return false;
+      }
     };
 
     TimelineHelper.prototype.changeTimezone  = function (timezone) {
@@ -51,10 +58,15 @@ define(function (require) {
     TimelineHelper.prototype.pluckLabel = function (hit, params, notify) {
       let field;
       if (params.labelFieldSequence) { // in kibi, we have the path property of a field
-        field = kibiUtils.getValuesAtPath(hit._source, params.labelFieldSequence);
+        if (this.isMultifield(params.labelFieldSequence[0])) {
+          field = kibiUtils.getValuesAtPath(hit.fields, params.labelFieldSequence);
+        } else {
+          field = kibiUtils.getValuesAtPath(hit._source, params.labelFieldSequence);
+        }
       } else {
         field = _.get(hit._source, params.labelField);
       }
+
       if (field && (!_.isArray(field) || field.length)) {
         return field;
       }


### PR DESCRIPTION
Closes #84 

It was tested with the following configuration.

**Mapping**

```
{
  "mappings": {
    "my_city": {
      "properties": {
        "city": {
          "type": "string",
          "fields": {
            "raw": {
              "type":  "string",
              "index": "not_analyzed",
              "doc_values": true
            },
            "rawcity": {
              "type":  "string",
              "index": "not_analyzed",
              "doc_values": true
            },
            "raw_city": {
              "type":  "string",
              "index": "not_analyzed",
              "doc_values": true
            }
          }
        },
        "arrive": {
          "type": "date",
          "fields": {
            "raw_date": {
              "type": "date",
              "doc_values": true
            },
            "raw": {
              "type": "date",
              "doc_values": true
            }
          }
        },
        "depart": {
          "type": "date",
          "fields": {
            "raw": {
              "type": "date",
              "doc_values": true
            }
          }
        }
      }
    }
  }
}
```

**Documents**

```
{
  "city": "New York",
  "arrive": "2016-07-11",
  "depart": "2016-09-05"
},
{
  "city": "York",
  "arrive": "2015-07-11",
  "depart": "2015-09-05"
}

```