### PR TITLE
Update vis lib to 4.17.0

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -3,6 +3,6 @@
   "version": "4.6.3",
   "dependencies": {
     "lodash": "3.10.1",
-    "vis": "4.9.0"
+    "vis": "4.17.0"
   }
 }


### PR DESCRIPTION
Closes #81 

Updated, after `bower install`:
```
[trex@Latitude-E5510 kibi_timeline_vis]$ head public/webpackShims/bower_components/vis/dist/vis.js |grep ver
 * @version 4.17.0
```

No error found during test.

