### PR TITLE
enable saved search selection filtering

### DIFF
--- a/public/kibi_timeline_vis_params.html
+++ b/public/kibi_timeline_vis_params.html
@@ -15,7 +15,7 @@
 
           <div class="form-group">
             <label>Saved search id</label>
-            <kibi-select-port required object-type="search" ng-model="group.savedSearchId">
+            <kibi-select-port required object-type="search" filterable="true" ng-model="group.savedSearchId">
             </kibi-select-port>
           </div>
 

--- a/public/lib/directives/kibi_select.html
+++ b/public/lib/directives/kibi_select.html
@@ -28,6 +28,8 @@
 
   <input ng-show="getVariable" type="text" ng-model="modelObject.value" class="form-control"/>
 
+  <input ng-show="filterable" placeholder="Filter" ng-model="itemsFilter" ng-change="filterItems()" ng-model-options="{debounce:750}" class="form-control"/>
+
   <select
     ng-class="{ 'red-border' : !isValid }"
     ng-show="!getVariable"

--- a/public/lib/directives/kibi_select.js
+++ b/public/lib/directives/kibi_select.js
@@ -31,7 +31,8 @@ define(function (require) {
         modelDisabled:    '=?', // use to disable the underlying select
         modelRequired:    '=?', // use to disable the underlying select
         include:          '=?', // extra values can be passed here
-        analyzedWarning:  '@'   // set to true or false to disable/enable analyzed field warning
+        analyzedWarning:  '@',  // set to true or false to disable/enable analyzed field warning
+        filterable:       '=?' // optional - enable selection filtering
       },
       template: require('./kibi_select.html'),
       link: function (scope, element, attrs, ngModelCtrl) {
@@ -168,7 +169,7 @@ define(function (require) {
 
           switch (scope.objectType) {
             case 'search':
-              promise = selectHelper.getObjects(scope.objectType);
+              promise = selectHelper.getObjects(scope.objectType, scope.itemsFilter);
               break;
             case 'field':
               promise = selectHelper.getFields(scope.indexPatternId, scope.fieldTypes);
@@ -182,6 +183,11 @@ define(function (require) {
               ngModelCtrl.$setValidity('stSelect', false);
             });
           }
+        };
+
+        scope.filterItems = function () {
+          scope.itemsFilter = this.itemsFilter;
+          _render();
         };
 
         scope.$watchMulti(['indexPatternId', 'indexPatternType', 'queryId', 'include', 'modelDisabled', 'modelRequired'], function () {

--- a/public/lib/directives/kibi_select_helper.js
+++ b/public/lib/directives/kibi_select_helper.js
@@ -3,10 +3,8 @@ define(function (require) {
   const chrome = require('ui/chrome');
 
   return function KibiSelectHelperFactory(
-    config, $http, courier, indexPatterns, timefilter, Private, Promise, kbnIndex
+    config, $http, courier, indexPatterns, timefilter, Private, Promise, kbnIndex, savedSearches
     ) {
-
-    const searchService = Private(require('ui/saved_objects/saved_object_registry')).byLoaderPropertiesName.searches;
 
     function KibiSelectHelper() {
     }
@@ -18,7 +16,7 @@ define(function (require) {
     };
 
     KibiSelectHelper.prototype.getObjects = function (type, filter) {
-      return searchService.find(filter).then(function (resp) {
+      return savedSearches.find(filter).then(function (resp) {
         const items = _.map(resp.hits, function (hit) {
           return {
             label: hit.title,

--- a/public/lib/directives/kibi_select_helper.js
+++ b/public/lib/directives/kibi_select_helper.js
@@ -6,6 +6,8 @@ define(function (require) {
     config, $http, courier, indexPatterns, timefilter, Private, Promise, kbnIndex
     ) {
 
+    const searchService = Private(require('ui/saved_objects/saved_object_registry')).byLoaderPropertiesName.searches;
+
     function KibiSelectHelper() {
     }
 
@@ -15,17 +17,15 @@ define(function (require) {
       return $http.get(chrome.getBasePath() + '/elasticsearch/' + kbnIndex + '/' + type + '/_search?size=100');
     };
 
-    KibiSelectHelper.prototype.getObjects = function (type) {
-      return searchRequest(type).then(function (objects) {
-        if (objects.data.hits && objects.data.hits.hits) {
-          const items = _.map(objects.data.hits.hits, function (hit) {
-            return {
-              label: hit._source.title,
-              value: hit._id
-            };
-          });
-          return items;
-        }
+    KibiSelectHelper.prototype.getObjects = function (type, filter) {
+      return searchService.find(filter).then(function (resp) {
+        const items = _.map(resp.hits, function (hit) {
+          return {
+            label: hit.title,
+            value: hit.id
+          };
+        });
+        return items;
       });
     };
 


### PR DESCRIPTION
Adds an input to the `kibiSelectPort` directive. The value of this input is used to query saved searches. When the value changes, an `elasticsearch/.kibana/search/_search?size=100` request is sent to the server to request saved searches containing the input value in either the title or description. 

The ability to filter saved searches allows users to select saved searches once the kibana index exceeds 100 saved searches as defined in issue #99. The ability to filter saved searches also allows users to easily find a saved search as the selection list gets longer.

![image](https://cloud.githubusercontent.com/assets/373691/21559002/d0ff5438-ce00-11e6-904f-0eed6f136cf9.png)

close #99 

 