### PR TITLE
Optionally split array field in multiple instances

### DIFF
--- a/public/kibi_timeline_vis_controller.js
+++ b/public/kibi_timeline_vis_controller.js
@@ -86,6 +86,7 @@ define(function (require) {
                   endField: group.endField,
                   //params for both
                   useHighlight: group.useHighlight,
+                  splitOnArray: group.splitOnArray,
                   invertFirstLabelInstance: group.invertFirstLabelInstance
                 }
               });

--- a/public/kibi_timeline_vis_params.html
+++ b/public/kibi_timeline_vis_params.html
@@ -34,6 +34,13 @@
                 Show highlighted terms
                 <kbn-info info="Show highlighted terms in event label."></kbn-info>
              </label>
+             <label>
+                <input type="checkbox"
+                       name="splitOnArray"
+                       ng-model="group.splitOnArray">
+                Show values in array field as seperate instances
+                <kbn-info info="Show seperate instances for every field in an field with multiple values. When unchecked, the values will be combined by a comma."></kbn-info>
+             </label>
             <label>
               <input type="checkbox"
                 name="highlightFirstLabelInstance"

--- a/public/lib/helpers/__tests__/timeline_helper.js
+++ b/public/lib/helpers/__tests__/timeline_helper.js
@@ -61,6 +61,24 @@ describe('Kibi Timeline', function () {
         sinon.assert.notCalled(notify.warning);
       });
 
+      it('should return the label of an event kibi-style', function () {
+        const hit = {
+          _source: {
+            aaa: {
+              bbb: {
+                ccc: 'ddd'
+              }
+            }
+          }
+        };
+        const params = {
+          labelField: 'aaa.bbb.ccc'
+        };
+
+        expect(timelineHelper.pluckLabel(hit, params, notify)).to.eql(['ddd']);
+        sinon.assert.notCalled(notify.warning);
+      });
+
       it('should return N/A if the event does not a value for the labelField', function () {
         const hit = {
           _source: {

--- a/public/lib/helpers/timeline_helper.js
+++ b/public/lib/helpers/timeline_helper.js
@@ -28,7 +28,9 @@ define(function (require) {
       if (params.labelFieldSequence) { // in kibi, we have the path property of a field
         field = kibiUtils.getValuesAtPath(hit._source, params.labelFieldSequence);
       } else { // create kibi path property from ES path by splitting on .
-        field = kibiUtils.getValuesAtPath(hit._source, Array.of(params.labelField.split('.')));
+        const kibanaSplit = params.labelField.split('.');
+        const kibanaSequence = Array.isArray(kibanaSplit) ? kibanaSplit : Array.of(kibanaSplit);
+        field = kibiUtils.getValuesAtPath(hit._source, kibanaSequence);
       }
       if (field && (!_.isArray(field) || field.length)) {
         return field;

--- a/public/lib/helpers/timeline_helper.js
+++ b/public/lib/helpers/timeline_helper.js
@@ -27,8 +27,8 @@ define(function (require) {
       let field;
       if (params.labelFieldSequence) { // in kibi, we have the path property of a field
         field = kibiUtils.getValuesAtPath(hit._source, params.labelFieldSequence);
-      } else {
-        field = _.get(hit._source, params.labelField);
+      } else { // create kibi path property from ES path by splitting on .
+        field = kibiUtils.getValuesAtPath(hit._source, params.labelField.split('.'));
       }
       if (field && (!_.isArray(field) || field.length)) {
         return field;

--- a/public/lib/helpers/timeline_helper.js
+++ b/public/lib/helpers/timeline_helper.js
@@ -28,7 +28,7 @@ define(function (require) {
       if (params.labelFieldSequence) { // in kibi, we have the path property of a field
         field = kibiUtils.getValuesAtPath(hit._source, params.labelFieldSequence);
       } else { // create kibi path property from ES path by splitting on .
-        field = kibiUtils.getValuesAtPath(hit._source, Array.of(params.labelField.split('.'))));
+        field = kibiUtils.getValuesAtPath(hit._source, Array.of(params.labelField.split('.')));
       }
       if (field && (!_.isArray(field) || field.length)) {
         return field;

--- a/public/lib/helpers/timeline_helper.js
+++ b/public/lib/helpers/timeline_helper.js
@@ -28,7 +28,7 @@ define(function (require) {
       if (params.labelFieldSequence) { // in kibi, we have the path property of a field
         field = kibiUtils.getValuesAtPath(hit._source, params.labelFieldSequence);
       } else { // create kibi path property from ES path by splitting on .
-        field = kibiUtils.getValuesAtPath(hit._source, params.labelField.split('.'));
+        field = kibiUtils.getValuesAtPath(hit._source, Array.of(params.labelField.split('.'))));
       }
       if (field && (!_.isArray(field) || field.length)) {
         return field;


### PR DESCRIPTION
Based on patch-1, adds the option to split array field into multiple instances, instead of joining on ', '. Integration tests have not been added.

<img width="488" alt="visualize - kibana - google chrome 17-1-2017 18_11_19" src="https://cloud.githubusercontent.com/assets/8270394/22031265/744a051e-dce0-11e6-8e97-a427844dfcd7.png">
<img width="488" alt="visualize - kibana - google chrome 17-1-2017 18_11_57" src="https://cloud.githubusercontent.com/assets/8270394/22031266/74502c28-dce0-11e6-85d4-8727e0940140.png">
