### PR TITLE
fix highlightTags import (kibana 5.3)

### DIFF
--- a/public/kibi_timeline.js
+++ b/public/kibi_timeline.js
@@ -6,10 +6,11 @@ import _ from 'lodash';
 import vis from 'vis';
 import buildRangeFilter from 'ui/filter_manager/lib/range';
 import uiModules from 'ui/modules';
+import highlightTags from 'ui/highlight/highlight_tags';
 
 uiModules
 .get('kibana')
-.directive('kibiTimeline', function (Private, createNotifier, courier, indexPatterns, config, highlightTags, timefilter) {
+.directive('kibiTimeline', function (Private, createNotifier, courier, indexPatterns, config, timefilter) {
   const NUM_FRAGS_CONFIG = 'kibi:timeline:highlight:number_of_fragments';
   const DEFAULT_NUM_FRAGS = 25;
   const requestQueue = Private(RequestQueueProvider);


### PR DESCRIPTION
In kibana 5.3, highlightTags was moved from angular constant to just a standard module. This pull requests changes how highlightTags is loaded to accommodate.