### PR TITLE
Add /kibana folder to built zip

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -16,7 +16,7 @@ var packageName = pkg.name  + '-' + pkg.version;
 
 var buildDir = path.resolve(__dirname, 'build');
 var targetDir = path.resolve(__dirname, 'target');
-var buildTarget = path.resolve(buildDir, packageName);
+var buildTarget = path.resolve(buildDir, 'kibana', packageName);
 
 var include = [
   'package.json',


### PR DESCRIPTION
Fixes the file structure within the zipped archive to 
/kibana
->   /kibi_timeline_viz
 -> ->     /etc

This allows kibi-plugin and kibana-plugin installations. 

Related to https://github.com/sirensolutions/kibi-distribution/issues/424