### PR TITLE
Do not store indexPatternId when saving the vis

### DIFF
--- a/public/kibi_timeline_vis_params.html
+++ b/public/kibi_timeline_vis_params.html
@@ -3,7 +3,12 @@
   <div class="form-group">
     <label>Groups</label></br>
     <ul>
-      <li ng-repeat="group in vis.params.groups" class="queryOptionArea" >
+      <!--
+        NOTE:
+        Render the group when $$indexPatternId was set
+        to prevent kibi-select-port to reset the model value to an empty string
+      -->
+      <li ng-repeat="group in vis.params.groups" class="queryOptionArea" ng-if="group.$$indexPatternId">
 
         <div class="header">
           Group {{$index + 1}}
@@ -42,19 +47,19 @@
               <kbn-info info="Cut through the clutter and make unique label values standout. When checked, the first instance of a label will be displayed with inverted colors."></kbn-info>
               </label>
             </div>
-            <kibi-select-port required object-type="field" index-pattern-id="group.indexPatternId" ng-model="group.labelField">
+            <kibi-select-port required object-type="field" index-pattern-id="group.$$indexPatternId" ng-model="group.labelField">
             </kibi-select-port>
           </div>
 
           <div class="form-group">
             <label>Event start date</label>
-            <kibi-select-port required object-type="field" index-pattern-id="group.indexPatternId" field-types="['date']" ng-model="group.startField">
+            <kibi-select-port required object-type="field" index-pattern-id="group.$$indexPatternId" field-types="['date']" ng-model="group.startField">
             </kibi-select-port>
           </div>
 
           <div class="form-group">
             <label>Event end date  <span class="small_note">(Optional)</span></label>
-            <kibi-select-port object-type="field" index-pattern-id="group.indexPatternId" field-types="['date']" ng-model="group.endField">
+            <kibi-select-port object-type="field" index-pattern-id="group.$$indexPatternId" field-types="['date']" ng-model="group.endField">
             </kibi-select-port>
           </div>
 


### PR DESCRIPTION
close #166 

```
{
        "indexPatternId": "article" // <-- this was redundant
        "savedSearchId": "Articles",
        "color": "#6f87d8",
        "endField": "",
        "groupLabel": "Articles",
        "id": 5000,
        "labelField": "title",
        "size": "10",
        "startField": "pdate"
}
```
Now it is not stored anymore
Bonus: The number of calls to fetch savedSearches was greatly reduced by introducing the init() function