### PR TITLE
7186 internal - prevent timeline being invisible in certain situations

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "grunt-cli": "^1.2.0",
     "kibi-icons": "sirensolutions/kibi-icons#1.1.0",
     "kibiutils": "sirensolutions/kibiutils#1.8.0",
-    "vis": "4.21.0"
+    "vis": "4.20.1"
   },
   "devDependencies": {
     "babel-eslint": "6.1.2",
@@ -38,7 +38,7 @@
     "gulp-util": "^3.0.7",
     "gulp-zip": "4.0.0",
     "husky": "0.14.3",
-    "lodash": "^3.10.1",
+    "lodash": "4.17.5",
     "minimist": "1.2.0",
     "mkdirp": "^0.5.1",
     "rimraf": "2.6.2",

--- a/public/kibi_timeline_vis_controller.js
+++ b/public/kibi_timeline_vis_controller.js
@@ -130,7 +130,7 @@ function controller(createNotifier, $location, $rootScope, $scope, $route, saved
   // Set to true in editing mode
   const configMode = $location.path().indexOf('/visualize/') !== -1;
 
-  $scope.savedVis = $route.current.locals.savedVis;
+  $scope.savedVis = $route.current.locals && $route.current.locals.savedVis;
   if (!$scope.savedVis) {
     // NOTE: reloading the visualization to get the searchSource,
     // which would otherwise be unavailable by design
@@ -181,7 +181,7 @@ function controller(createNotifier, $location, $rootScope, $scope, $route, saved
   // requiresSearch set to true since it needs more that one search.
 
   // on kibi, the editors.js file is updated to support requiresMultiSearch so that a courier.fetch call is executed
-  const isKibi = chrome.getAppTitle() === 'Kibi';
+  const isKibi = chrome.getAppTitle() === 'Investigate';
 
   // update the searchSource when filters update
   $scope.$listen(queryFilter, 'update', function () {

--- a/public/kibi_timeline_vis_controller.js
+++ b/public/kibi_timeline_vis_controller.js
@@ -181,12 +181,12 @@ function controller(createNotifier, $location, $rootScope, $scope, $route, saved
   // requiresSearch set to true since it needs more that one search.
 
   // on kibi, the editors.js file is updated to support requiresMultiSearch so that a courier.fetch call is executed
-  const isKibi = chrome.getAppTitle() === 'Investigate';
+  const isInvestigate = chrome.getAppTitle() === 'Investigate';
 
   // update the searchSource when filters update
   $scope.$listen(queryFilter, 'update', function () {
     _.each($scope.visOptions.groups, group => group.searchSource.set('filter', queryFilter.getFilters()));
-    if (!isKibi) {
+    if (!isInvestigate) {
       courier.fetch();
     }
   });
@@ -195,7 +195,7 @@ function controller(createNotifier, $location, $rootScope, $scope, $route, saved
     _.each($scope.visOptions.groups, group => {
       group.searchSource.fetchQueued();
     });
-    if (!isKibi) {
+    if (!isInvestigate) {
       courier.fetch();
     }
   });


### PR DESCRIPTION
It seems that the timeline issue was introduced by 
https://github.com/almende/vis/issues/3529
There are 3 tickets referenced in this ticket after "On timeline loaded #3530" PR was merged and included in vis.js 4.21.0 release
For now, I've reverted back to 4.20.1 and the problem does not appear anymore

We could either wait for the fix and new release or fork it 
remove the 1 offending PR  from 4.21.0 and release our 4.21.0-siren

<img width="839" alt="timeline" src="https://user-images.githubusercontent.com/900118/47495715-c3451a00-d84c-11e8-993a-0edecccc39f5.png">

