### PR TITLE
[INVE-714] Add noreferrer and noopener to links that open in a new tab

### DIFF
--- a/public/lib/directives/kibi_select.html
+++ b/public/lib/directives/kibi_select.html
@@ -22,7 +22,7 @@
 
   <div class="hintbox" ng-show="showAnalyzedFieldWarning">
     <p>
-      <strong>Careful!</strong> The field selected contains analyzed strings. Values such as <i>foo-bar</i> will be broken into <i>foo</i> and <i>bar</i>. See <a href="http://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-core-types.html" target="_blank">Mapping Core Types</a> for more information on setting this field as <i>not_analyzed</i>
+      <strong>Careful!</strong> The field selected contains analyzed strings. Values such as <i>foo-bar</i> will be broken into <i>foo</i> and <i>bar</i>. See <a href="http://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-core-types.html" target="_blank" rel="noopener noreferrer">Mapping Core Types</a> for more information on setting this field as <i>not_analyzed</i>
     </p>
   </div>
 


### PR DESCRIPTION
Due to security vulnerability present when using `_blank` as described [here](https://support.detectify.com/customer/portal/articles/2792257-external-links-using-target-_blank-) and [here](https://dev.to/ben/the-targetblank-vulnerability-by-example).